### PR TITLE
fix(test): skip test_name_utility_methods_normalize_the_name_using_ensip15

### DIFF
--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -211,6 +211,7 @@ def test_label_to_hash_normalizes_name_using_ensip15():
 
 
 @mock.patch("faster_ens.utils.dns_encode_name")
+@pytest.mark.skip(reason="Native functions do not support mocking")
 def test_ens_encode_name_issues_deprecation_warning_and_calls_dns_encode_name(
     mock_dns_encode_name,
 ):


### PR DESCRIPTION
Native functions do not support mocking