### PR TITLE
fix(benchmark): split raw RPC and pythonic formatter fixtures

### DIFF
--- a/benchmarks/web3/_utils/params.py
+++ b/benchmarks/web3/_utils/params.py
@@ -15,6 +15,34 @@ TX_DICT = {
     "gasPrice": 50000000000,
 }
 
+RAW_TX_DICT = {
+    "blockHash": HASH32,
+    "blockNumber": "0xbc614e",
+    "transactionIndex": "0x0",
+    "hash": HASH32,
+    "from": TX_DICT["from"],
+    "to": TX_DICT["to"],
+    "value": "0xde0b6b3a7640000",
+    "gas": "0x5208",
+    "input": "0x",
+    "nonce": "0xc",
+    "gasPrice": "0xba43b7400",
+    "type": "0x2",
+    "chainId": "0x1",
+    "accessList": [],
+    "maxFeePerGas": "0x12a05f200",
+    "maxPriorityFeePerGas": "0x77359400",
+}
+
+RAW_SIGNED_TX_DICT = {
+    "raw": (
+        "0xf86c808504a817c80082520894bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        "880de0b6b3a76400008025a0b1e1b1e1b1e1b1e1b1e1b1e1b1e1b1e1b1e1b1e1b1e1b1e1"
+        "a06e1a06e1a06e1a06e1a06e1a06e1a06e1a06e1a06e1a06e1a06e1"
+    ),
+    "tx": RAW_TX_DICT,
+}
+
 # Log entry (mainnet-style)
 LOG_ENTRY = {
     "address": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
@@ -29,6 +57,14 @@ LOG_ENTRY = {
     "logIndex": 0,
 }
 
+RAW_LOG_ENTRY = {
+    **LOG_ENTRY,
+    "blockHash": HASH32,
+    "blockNumber": "0xbc614e",
+    "transactionIndex": "0x0",
+    "logIndex": "0x0",
+}
+
 # Block dict (mainnet-style, minimal for formatter)
 BLOCK_DICT = {
     "number": 12345678,
@@ -38,6 +74,22 @@ BLOCK_DICT = {
     "miner": "0x829BD824B016326A401d083B33D092293333A830",
     "gasLimit": 15000000,
     "gasUsed": 12000000,
+}
+
+RAW_BLOCK_DICT = {
+    **BLOCK_DICT,
+    "number": "0xbc614e",
+    "transactions": [RAW_TX_DICT, RAW_TX_DICT],
+    "logs": [RAW_LOG_ENTRY, RAW_LOG_ENTRY],
+    "gasLimit": "0xe4e1c0",
+    "gasUsed": "0xb71b00",
+    "baseFeePerGas": "0x77359400",
+    "timestamp": "0x65000000",
+    "parentHash": HASH32,
+    "sha3Uncles": HASH32,
+    "uncles": [],
+    "difficulty": "0x0",
+    "totalDifficulty": "0x0",
 }
 
 # Receipt dict (minimal)
@@ -58,12 +110,31 @@ RECEIPT_DICT = {
     "type": 2,
 }
 
+RAW_RECEIPT_DICT = {
+    **RECEIPT_DICT,
+    "blockNumber": RAW_BLOCK_DICT["number"],
+    "transactionIndex": "0x0",
+    "cumulativeGasUsed": "0x5208",
+    "status": "0x1",
+    "gasUsed": "0x5208",
+    "logs": [RAW_LOG_ENTRY],
+    "effectiveGasPrice": "0xba43b7400",
+    "type": "0x2",
+}
+
 # Fee history dict (minimal)
 FEE_HISTORY_DICT = {
     "baseFeePerGas": ["0x1", "0x2"],
     "gasUsedRatio": [0.5, 0.7],
     "oldestBlock": "0x5e1d3a76",
     "reward": [[1, 2], [3, 4]],
+}
+
+RAW_FEE_HISTORY_DICT = {
+    "baseFeePerGas": ["0x1", "0x2"],
+    "gasUsedRatio": [0.5, 0.7],
+    "oldestBlock": "0x5e1d3",
+    "reward": [["0x1", "0x2"], ["0x3", "0x4"]],
 }
 
 # Storage key cases for storage_key_to_hexstr

--- a/benchmarks/web3/_utils/test_method_formatters_benchmarks.py
+++ b/benchmarks/web3/_utils/test_method_formatters_benchmarks.py
@@ -8,12 +8,13 @@ from pytest_codspeed import BenchmarkFixture
 
 from benchmarks.batching import run_1000
 from benchmarks.web3._utils.params import (
-    BLOCK_DICT,
-    FEE_HISTORY_DICT,
     HASH32,
-    LOG_ENTRY,
-    RECEIPT_DICT,
-    TX_DICT,
+    RAW_BLOCK_DICT,
+    RAW_FEE_HISTORY_DICT,
+    RAW_LOG_ENTRY,
+    RAW_RECEIPT_DICT,
+    RAW_SIGNED_TX_DICT,
+    RAW_TX_DICT,
 )
 
 # --- SYSTEMATIC BENCHMARKS FOR PYTHONIC_RESULT_FORMATTERS ---
@@ -114,7 +115,7 @@ RESULT_DATA = {
     "eth_sendTransaction": "0xfeedbabe1234567890cafebabe1234567890feedbabe1234567890cafebabe12",
     "eth_signTypedData": "0x1c6401ff0c2b6a1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1c1",
     "eth_getRawTransactionByHash": HASH32,
-    "eth_getTransactionByHash": TX_DICT,
+    "eth_getTransactionByHash": RAW_TX_DICT,
     "eth_getUncleCountByBlockHash": "0x2",
     "eth_getUncleCountByBlockNumber": "0x2",
     "eth_getStorageAt": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -128,8 +129,8 @@ RESULT_DATA = {
         "storageHash": "0x5e1d3a76fbf824220e3d1e4b8b1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1c1b6b1",
         "storageProof": [],
     },
-    "eth_getTransactionByBlockHashAndIndex": TX_DICT,
-    "eth_getTransactionByBlockNumberAndIndex": TX_DICT,
+    "eth_getTransactionByBlockHashAndIndex": RAW_TX_DICT,
+    "eth_getTransactionByBlockNumberAndIndex": RAW_TX_DICT,
     "eth_subscribe": {
         "result": HASH32
     },
@@ -169,15 +170,15 @@ RESULT_DATA = {
         "to": "0x53d284357ec70cE289D6D64134DfAc8E511c8a3D",
         "value": "0x8ac7230489e80000",
     },
-    "eth_feeHistory": FEE_HISTORY_DICT,
-    "eth_getBlockByHash": BLOCK_DICT,
-    "eth_getBlockByNumber": BLOCK_DICT,
-    "eth_getBlockReceipts": [RECEIPT_DICT],
-    "eth_getFilterChanges": [LOG_ENTRY],
-    "eth_getFilterLogs": [LOG_ENTRY],
-    "eth_getLogs": [LOG_ENTRY],
-    "eth_getTransactionReceipt": RECEIPT_DICT,
-    "eth_signTransaction": TX_DICT,
+    "eth_feeHistory": RAW_FEE_HISTORY_DICT,
+    "eth_getBlockByHash": RAW_BLOCK_DICT,
+    "eth_getBlockByNumber": RAW_BLOCK_DICT,
+    "eth_getBlockReceipts": [RAW_RECEIPT_DICT],
+    "eth_getFilterChanges": [RAW_LOG_ENTRY],
+    "eth_getFilterLogs": [RAW_LOG_ENTRY],
+    "eth_getLogs": [RAW_LOG_ENTRY],
+    "eth_getTransactionReceipt": RAW_RECEIPT_DICT,
+    "eth_signTransaction": RAW_SIGNED_TX_DICT,
     "trace_block": [TRACE] * 1000,
     "trace_transaction": [TRACE] * 50,
     "trace_filter": [TRACE] * 2000,


### PR DESCRIPTION
## Summary

Split benchmark fixture data for raw JSON-RPC formatter inputs from already-Pythonic benchmark fixtures.

## Rationale

The benchmark suite is green on `master`, so broad shared fixture changes need to be narrow and defensible. ENS does not need special dtype behavior. The actual issue is that `PYTHONIC_RESULT_FORMATTERS` benchmarks should receive raw RPC-shaped values, while other benchmark consumers should keep the existing Pythonic fixture names and values.

## Details

- Keep existing `TX_DICT`, `BLOCK_DICT`, `LOG_ENTRY`, `RECEIPT_DICT`, and `FEE_HISTORY_DICT` names stable for Pythonic benchmark consumers.
- Add explicit raw fixtures: `RAW_TX_DICT`, `RAW_BLOCK_DICT`, `RAW_LOG_ENTRY`, `RAW_RECEIPT_DICT`, `RAW_FEE_HISTORY_DICT`, plus `RAW_SIGNED_TX_DICT` for `eth_signTransaction` result formatting.
- Update only `benchmarks/web3/_utils/test_method_formatters_benchmarks.py` result formatter inputs to use raw fixtures.
- Remove the old ENS-specific fixture changes and avoid changing `benchmarks/ens/fake_rpc.py` in this PR.

## Validation

- `python3 -m compileall -q benchmarks`
- `uv run python -m pytest --collect-only benchmarks/web3/_utils/test_method_formatters_benchmarks.py`
- `uv run python -m pytest --benchmark-disable benchmarks/web3/_utils/test_method_formatters_benchmarks.py`
- `uv run python -m pytest --collect-only benchmarks/`

Note: full `uv run python -m pytest --benchmark-disable benchmarks/` was started, but existing ENS benchmark failures appeared before the changed formatter files and the broader smoke later hung in the existing suite. The targeted formatter smoke passed.