### PR TITLE
fix(benchmarks): standardize benchmark run helpers

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,28 +3,28 @@ name: Benchmark Suite
 on:
   pull_request:
     branches: [main, master]
-    paths-ignore:
-      - '.circleci/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/benchmark.yaml'
-      - '!.github/workflows/codspeed.yaml'
-      - 'scripts/**'
-      - 'tests/**'
+    paths:
+      - '.github/workflows/benchmark.yaml'
+      - 'faster_web3/**'
+      - 'faster_ens/**'
+      - 'benchmarks/**'
+      - 'scripts/benchmark/**'
+      - 'setup.py'
+      - 'pyproject.toml'
       - 'tox.ini'
-      - '.gitignore'
-      - '*.md'
+      - 'requirements*.txt'
   push:
     branches: [main, master]
-    paths-ignore:
-      - '.circleci/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/benchmark.yaml'
-      - '!.github/workflows/codspeed.yaml'
-      - 'scripts/**'
-      - 'tests/**'
+    paths:
+      - '.github/workflows/benchmark.yaml'
+      - 'faster_web3/**'
+      - 'faster_ens/**'
+      - 'benchmarks/**'
+      - 'scripts/benchmark/**'
+      - 'setup.py'
+      - 'pyproject.toml'
       - 'tox.ini'
-      - '.gitignore'
-      - '*.md'
+      - 'requirements*.txt'
   workflow_dispatch:
     inputs:
       run-type:
@@ -58,12 +58,14 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
             faster_web3/**/*.py
             faster_ens/**/*.py
           pip-cache-dependency-path: |
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
           ccache: true
 
   codspeed-benchmark:
@@ -87,6 +89,7 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
 
       - name: Download wheel
         uses: actions/download-artifact@v8
@@ -94,13 +97,13 @@ jobs:
           name: ${{ needs.build-wheel.outputs.artifact-name }}
           path: .
 
-      - name: Install built wheel and codspeed dependencies
+      - name: Install built wheel and benchmark dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "$(find . -name '*.whl')" -r requirements-codspeed.txt
+          python -m pip install "$(find . -name '*.whl')" -r requirements-benchmark.txt
 
       - name: Remove Python files from test env
-        run: rm -r faster_web3 faster_ens
+        run: rm -rf faster_web3 faster_ens
 
       - name: Run CodSpeed
         uses: CodSpeedHQ/action@v4
@@ -125,6 +128,7 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
 
       - name: Download built wheel artifact
         uses: actions/download-artifact@v8
@@ -139,9 +143,7 @@ jobs:
         run: pip install ./*.whl -r requirements-dev.txt -r requirements-benchmark.txt
           
       - name: Remove Python files from test env
-        run: |
-          rm -r faster_web3
-          rm -r faster_ens
+        run: rm -rf faster_web3 faster_ens
           
       - name: Run Pytest Benchmark & Save Output
         run: pytest --benchmark-only --benchmark-json=benchmark.json benchmarks/

--- a/benchmarks/batching.py
+++ b/benchmarks/batching.py
@@ -1,0 +1,135 @@
+import asyncio
+
+
+def _run_async(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def run_10(fn, *args, **kwargs):
+    for _ in range(10):
+        fn(*args, **kwargs)
+
+
+def run_10_exc(exc, fn, *args, **kwargs):
+    for _ in range(10):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_100(fn, *args, **kwargs):
+    for _ in range(100):
+        fn(*args, **kwargs)
+
+
+def run_100_exc(exc, fn, *args, **kwargs):
+    for _ in range(100):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_500(fn, *args, **kwargs):
+    for _ in range(500):
+        fn(*args, **kwargs)
+
+
+def run_500_exc(exc, fn, *args, **kwargs):
+    for _ in range(500):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_1000(fn, *args, **kwargs):
+    for _ in range(1000):
+        fn(*args, **kwargs)
+
+
+def run_1000_exc(exc, fn, *args, **kwargs):
+    for _ in range(1000):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_5000(fn, *args, **kwargs):
+    for _ in range(5000):
+        fn(*args, **kwargs)
+
+
+def run_5000_exc(exc, fn, *args, **kwargs):
+    for _ in range(5000):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_10000(fn, *args, **kwargs):
+    for _ in range(10000):
+        fn(*args, **kwargs)
+
+
+def run_10000_exc(exc, fn, *args, **kwargs):
+    for _ in range(10000):
+        try:
+            fn(*args, **kwargs)
+        except exc:
+            pass
+
+
+def run_10_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(10):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())
+
+
+def run_100_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(100):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())
+
+
+def run_500_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(500):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())
+
+
+def run_1000_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(1000):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())
+
+
+def run_5000_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(5000):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())
+
+
+def run_10000_async(fn, *args, **kwargs):
+    async def runner():
+        for _ in range(10000):
+            await fn(*args, **kwargs)
+
+    return _run_async(runner())

--- a/benchmarks/ens/test_base_ens_benchmarks.py
+++ b/benchmarks/ens/test_base_ens_benchmarks.py
@@ -1,14 +1,12 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import ens.base_ens
-    import ens.exceptions
-except ImportError:
-    pass
+import ens.base_ens
+import ens.exceptions
 
 import faster_ens.base_ens
 import faster_ens.exceptions
+from benchmarks.batching import run_10, run_10_exc
 from benchmarks.ens.params import (
     LABELS,
     NAMES_VALIDITY,
@@ -16,19 +14,6 @@ from benchmarks.ens.params import (
     PARENT_NAMES,
     parametrize_names_full_coverage,
 )
-
-
-def run_10(func, *args, **kwargs):
-    for _ in range(10):
-        func(*args, **kwargs)
-
-
-def run_10_exc(exc, func, *args, **kwargs):
-    for _ in range(10):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            pass
 
 
 @pytest.mark.benchmark(group="BaseENS.labelhash")

--- a/benchmarks/ens/test_ens_benchmarks.py
+++ b/benchmarks/ens/test_ens_benchmarks.py
@@ -4,12 +4,9 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from unittest.mock import patch
 
-try:
-    import ens.ens
-    import ens.exceptions
-    import web3
-except ImportError:
-    pass
+import ens.ens
+import ens.exceptions
+import web3
 
 import faster_ens.ens
 import faster_ens.exceptions
@@ -17,14 +14,7 @@ import faster_web3
 
 from benchmarks.ens.params import parametrize_names_full_coverage
 from benchmarks.ens.fake_rpc import fake_json_rpc_response, FAKE_ENS_REGISTRY
-
-
-def run_100(func, exc, *args, **kwargs):
-    for _ in range(100):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            pass
+from benchmarks.batching import run_100_exc
 
 
 class FakeResponse:
@@ -50,7 +40,7 @@ def test_address(benchmark: BenchmarkFixture, name):
         provider = web3.HTTPProvider("http://localhost:8545")
         # Patch the ENS registry address to our fake one
         ns = ens.ens.ENS(provider=provider, addr=FAKE_ENS_REGISTRY)
-        benchmark(run_100, ens.exceptions.ENSException, ns.address, name)
+        benchmark(run_100_exc, ens.exceptions.ENSException, ns.address, name)
 
 
 @pytest.mark.benchmark(group="ENS.address")
@@ -59,4 +49,4 @@ def test_faster_address(benchmark: BenchmarkFixture, name):
     with patch("requests.Session.send", side_effect=fake_send):
         provider = faster_web3.HTTPProvider("http://localhost:8545")
         ns = faster_ens.ens.ENS(provider=provider, addr=FAKE_ENS_REGISTRY)
-        benchmark(run_100, faster_ens.exceptions.ENSException, ns.address, name)
+        benchmark(run_100_exc, faster_ens.exceptions.ENSException, ns.address, name)

--- a/benchmarks/ens/test_normalization_benchmarks.py
+++ b/benchmarks/ens/test_normalization_benchmarks.py
@@ -1,32 +1,21 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import ens._normalization
-    import ens.exceptions
-except ImportError:
-    pass
+import ens._normalization
+import ens.exceptions
 
 import faster_ens._normalization
 import faster_ens.exceptions
 
 from benchmarks.ens.params import parametrize_names_full_coverage
-
-
-def run_1000(func, exc, *args, **kwargs):
-    for _ in range(1000):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            # Some cases are expected to raise (invalid names)
-            pass
+from benchmarks.batching import run_1000_exc
 
 
 @pytest.mark.benchmark(group="normalize_name_ensip15")
 @parametrize_names_full_coverage
 def test_normalize_name_ensip15(benchmark: BenchmarkFixture, name):
     benchmark(
-        run_1000,
+        run_1000_exc,
         ens.exceptions.InvalidName,
         ens._normalization.normalize_name_ensip15,
         name,
@@ -37,7 +26,7 @@ def test_normalize_name_ensip15(benchmark: BenchmarkFixture, name):
 @parametrize_names_full_coverage
 def test_faster_normalize_name_ensip15(benchmark: BenchmarkFixture, name):
     benchmark(
-        run_1000,
+        run_1000_exc,
         faster_ens.exceptions.InvalidName,
         faster_ens._normalization.normalize_name_ensip15,
         name,

--- a/benchmarks/ens/test_utils_benchmarks.py
+++ b/benchmarks/ens/test_utils_benchmarks.py
@@ -1,12 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import ens.utils
-except ImportError:
-    pass
+import ens.utils
 
 import faster_ens.utils
+from benchmarks.batching import run_10, run_10_exc, run_500
 from benchmarks.ens.params import (
     NAMES,
     LABELS,
@@ -14,24 +12,6 @@ from benchmarks.ens.params import (
     LABEL_LISTS,
     parametrize_names_full_coverage,
 )
-
-
-def run_10(func, *args, **kwargs):
-    for _ in range(10):
-        func(*args, **kwargs)
-
-
-def run_10_exc(exc, func, *args, **kwargs):
-    for _ in range(10):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            pass
-
-
-def run_500(func, *args, **kwargs):
-    for _ in range(500):
-        func(*args, **kwargs)
 
 
 @pytest.mark.benchmark(group="normalize_name")

--- a/benchmarks/web3/_utils/test_abi_benchmarks.py
+++ b/benchmarks/web3/_utils/test_abi_benchmarks.py
@@ -1,23 +1,13 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.abi
-except ImportError:
-    pass
+import web3._utils.abi
 
 import faster_web3._utils.abi
+from benchmarks.batching import run_100, run_500
 
 
 # --- Helpers ---
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
-
-
-def run_500(func, *args, **kwargs):
-    for _ in range(500):
-        func(*args, **kwargs)
 
 
 # --- Type Checkers ---

--- a/benchmarks/web3/_utils/test_async_transactions_benchmarks.py
+++ b/benchmarks/web3/_utils/test_async_transactions_benchmarks.py
@@ -3,31 +3,11 @@ import asyncio
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.async_transactions
-except ImportError:
-    pass
+import web3._utils.async_transactions
 
 import faster_web3._utils.async_transactions
 import faster_hexbytes
-
-
-def run_1000(func, *args, **kwargs):
-    for _ in range(1000):
-        func(*args, **kwargs)
-
-
-async def _run_1000_async(func, *args, **kwargs):
-    for _ in range(1000):
-        await func(*args, **kwargs)
-
-
-def run_1000_async(func, *args, **kwargs):
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(_run_1000_async(func, *args, **kwargs))
-    finally:
-        loop.close()
+from benchmarks.batching import run_1000, run_1000_async
 
 
 # --- Realistic transactions and blocks ---

--- a/benchmarks/web3/_utils/test_batching_benchmarks.py
+++ b/benchmarks/web3/_utils/test_batching_benchmarks.py
@@ -1,35 +1,14 @@
-import asyncio
 import contextvars
 
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.batching
-    import web3.types
-except ImportError:
-    pass
+import web3._utils.batching
+import web3.types
 
 import faster_web3._utils.batching
 import faster_web3.types
-
-
-def run_1000(func, *args, **kwargs):
-    for _ in range(1000):
-        func(*args, **kwargs)
-
-
-async def _run_1000_async(func, *args, **kwargs):
-    for _ in range(1000):
-        await func(*args, **kwargs)
-
-
-def run_1000_async(func, *args, **kwargs):
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(_run_1000_async(func, *args, **kwargs))
-    finally:
-        loop.close()
+from benchmarks.batching import run_1000, run_1000_async
 
 
 def noop(value):

--- a/benchmarks/web3/_utils/test_blocks_benchmarks.py
+++ b/benchmarks/web3/_utils/test_blocks_benchmarks.py
@@ -1,19 +1,12 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.blocks
-except ImportError:
-    pass
+import web3._utils.blocks
 
 import faster_web3._utils.blocks
+from benchmarks.batching import run_100
 
 _object = object()
-
-
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
 
 
 def run_100_exc(func, expected_exc, *args, **kwargs):

--- a/benchmarks/web3/_utils/test_decorators_benchmarks.py
+++ b/benchmarks/web3/_utils/test_decorators_benchmarks.py
@@ -3,17 +3,10 @@ import warnings
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.decorators
-except ImportError:
-    pass
+import web3._utils.decorators
 
 import faster_web3._utils.decorators
-
-
-def run_10000(fn, *args, **kwargs):
-    for _ in range(10000):
-        fn(*args, **kwargs)
+from benchmarks.batching import run_10000
 
 
 def _noop(value):

--- a/benchmarks/web3/_utils/test_formatters_benchmarks.py
+++ b/benchmarks/web3/_utils/test_formatters_benchmarks.py
@@ -1,13 +1,11 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.formatters
-except ImportError:
-    pass
+import web3._utils.formatters
 
 import faster_web3._utils.formatters
 
+from benchmarks.batching import run_5000, run_5000_exc
 from benchmarks.web3._utils.params import (
     TX_DICT,
     LOG_ENTRY,
@@ -16,17 +14,6 @@ from benchmarks.web3._utils.params import (
 
 
 # --- Helpers ---
-def run_5000(func, *args, **kwargs):
-    for _ in range(5000):
-        func(*args, **kwargs)
-
-
-def run_5000_exc(exc, func, *args, **kwargs):
-    for _ in range(5000):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            pass
 
 
 def noop(x):

--- a/benchmarks/web3/_utils/test_http_benchmarks.py
+++ b/benchmarks/web3/_utils/test_http_benchmarks.py
@@ -1,17 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.http
-except ImportError:
-    pass
+import web3._utils.http
 
 import faster_web3._utils.http
-
-
-def run_1000(func, *args, **kwargs):
-    for _ in range(1000):
-        func(*args, **kwargs)
+from benchmarks.batching import run_1000
 
 
 MODULE = "some_module"

--- a/benchmarks/web3/_utils/test_http_session_manager_benchmarks.py
+++ b/benchmarks/web3/_utils/test_http_session_manager_benchmarks.py
@@ -1,15 +1,12 @@
-import asyncio
 from unittest.mock import patch
 
 import pytest
 
-try:
-    import web3._utils.http_session_manager
-except ImportError:
-    pass
+import web3._utils.http_session_manager
 
 import faster_web3._utils.http_session_manager
 
+from benchmarks.batching import run_10000, run_10000_async
 from benchmarks.mocking import (
     fake_requests_get,
     fake_requests_post,
@@ -28,24 +25,6 @@ JSON_RPC_PAYLOAD = {
     "params": [],
     "id": 1,
 }
-
-
-def run_10000(fn, *args, **kwargs):
-    for _ in range(10000):
-        fn(*args, **kwargs)
-
-
-async def _run_10000_async(fn, *args, **kwargs):
-    for _ in range(10000):
-        await fn(*args, **kwargs)
-
-
-def run_10000_async(fn, *args, **kwargs):
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(_run_10000_async(fn, *args, **kwargs))
-    finally:
-        loop.close()
 
 
 parametrize_endpoints = pytest.mark.parametrize(

--- a/benchmarks/web3/_utils/test_math_benchmarks.py
+++ b/benchmarks/web3/_utils/test_math_benchmarks.py
@@ -1,17 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.math
-except ImportError:
-    pass
+import web3._utils.math
 
 import faster_web3._utils.math
-
-
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
+from benchmarks.batching import run_100
 
 
 percentile_cases = [

--- a/benchmarks/web3/_utils/test_method_formatters_benchmarks.py
+++ b/benchmarks/web3/_utils/test_method_formatters_benchmarks.py
@@ -1,19 +1,20 @@
 import pytest
 
-try:
-    import web3._utils.method_formatters
-except ImportError:
-    pass
+import web3._utils.method_formatters
 
 import faster_web3._utils.method_formatters
 from faster_web3.types import RPCEndpoint
 from pytest_codspeed import BenchmarkFixture
 
-from benchmarks.web3._utils.params import BLOCK_DICT, FEE_HISTORY_DICT, HASH32, LOG_ENTRY, RECEIPT_DICT, TX_DICT
-
-def run_1000(fn, *args):
-    for _ in range(1000):
-        fn(*args)
+from benchmarks.batching import run_1000
+from benchmarks.web3._utils.params import (
+    BLOCK_DICT,
+    FEE_HISTORY_DICT,
+    HASH32,
+    LOG_ENTRY,
+    RECEIPT_DICT,
+    TX_DICT,
+)
 
 # --- SYSTEMATIC BENCHMARKS FOR PYTHONIC_RESULT_FORMATTERS ---
 

--- a/benchmarks/web3/_utils/test_request_caching_validation_benchmarks.py
+++ b/benchmarks/web3/_utils/test_request_caching_validation_benchmarks.py
@@ -4,11 +4,8 @@ import time
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.caching.request_caching_validation
-    import web3._utils.rpc_abi
-except ImportError:
-    pass
+import web3._utils.caching.request_caching_validation
+import web3._utils.rpc_abi
 
 import faster_web3._utils.caching.request_caching_validation
 import faster_web3._utils.rpc_abi

--- a/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
+++ b/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
@@ -1,17 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.utility_methods
-except ImportError:
-    pass
+import web3._utils.utility_methods
 
 import faster_web3._utils.utility_methods
-
-
-def run_5000(func, *args, **kwargs):
-    for _ in range(5000):
-        func(*args, **kwargs)
+from benchmarks.batching import run_5000
 
 
 dict_cases = [

--- a/benchmarks/web3/_utils/test_validation_benchmarks.py
+++ b/benchmarks/web3/_utils/test_validation_benchmarks.py
@@ -1,11 +1,8 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3._utils.validation
-    import web3.exceptions
-except ImportError:
-    pass
+import web3._utils.validation
+import web3.exceptions
 
 import faster_web3._utils.validation
 import faster_web3.exceptions
@@ -13,20 +10,10 @@ from eth_utils.abi import function_abi_to_4byte_selector
 from eth_utils.hexadecimal import encode_hex
 
 from benchmarks.web3._utils import abis
+from benchmarks.batching import run_1000, run_1000_exc
 
 
 # --- Helpers ---
-def run_1000(func, *args, **kwargs):
-    for _ in range(1000):
-        func(*args, **kwargs)
-
-
-def run_1000_exc(exc, func, *args, **kwargs):
-    for _ in range(1000):
-        try:
-            func(*args, **kwargs)
-        except exc:
-            pass
 
 
 # Real selector collision example: two functions with the same signature

--- a/benchmarks/web3/beacon/test_async_beacon_benchmarks.py
+++ b/benchmarks/web3/beacon/test_async_beacon_benchmarks.py
@@ -3,10 +3,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from unittest.mock import patch, AsyncMock
 
-try:
-    import web3.beacon
-except ImportError:
-    pass
+import web3.beacon
 
 import faster_web3.beacon
 

--- a/benchmarks/web3/beacon/test_beacon_benchmarks.py
+++ b/benchmarks/web3/beacon/test_beacon_benchmarks.py
@@ -2,10 +2,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from unittest.mock import patch
 
-try:
-    import web3.beacon
-except ImportError:
-    pass
+import web3.beacon
 
 import faster_web3.beacon
 
@@ -44,24 +41,6 @@ validator_indices_cases = [[], ["0"], ["1", "2", "3", "4", "5"]]
 indices_cases = [None, [0], [0, 1, 2, 3, 4]]
 block_roots = ["0xabc123", "0x0"]
 peer_ids = ["peer1", "peer2", "0xdeadbeef"]
-
-# --- Benchmarks for All Beacon Methods ---
-
-
-def run_1000(fn, *args, **kwargs):
-    if kwargs and args:
-        for _ in range(1000):
-            fn(*args, **kwargs)
-    elif args:
-        for _ in range(1000):
-            fn(*args)
-    elif kwargs:
-        for _ in range(1000):
-            fn(**kwargs)
-    else:
-        for i in range(1000):
-            fn()
-
 
 @pytest.mark.benchmark(group="beacon-get_genesis")
 def test_get_genesis(benchmark: BenchmarkFixture):

--- a/benchmarks/web3/providers/eth_tester/test_middleware_benchmarks.py
+++ b/benchmarks/web3/providers/eth_tester/test_middleware_benchmarks.py
@@ -3,30 +3,10 @@ import asyncio
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3.providers.eth_tester.middleware
-except ImportError:
-    pass
+import web3.providers.eth_tester.middleware
 
 import faster_web3.providers.eth_tester.middleware
-
-
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
-
-
-async def _run_100_async(func, *args, **kwargs):
-    for _ in range(100):
-        await func(*args, **kwargs)
-
-
-def run_100_async(func, *args, **kwargs):
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(_run_100_async(func, *args, **kwargs))
-    finally:
-        loop.close()
+from benchmarks.batching import run_100, run_100_async
 
 
 ADDRESS = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"

--- a/benchmarks/web3/providers/rpc/test_rpc_utils_benchmarks.py
+++ b/benchmarks/web3/providers/rpc/test_rpc_utils_benchmarks.py
@@ -1,17 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3.providers.rpc.utils
-except ImportError:
-    pass
+import web3.providers.rpc.utils
 
 import faster_web3.providers.rpc.utils
-
-
-def run_5000(func, *args, **kwargs):
-    for _ in range(5000):
-        func(*args, **kwargs)
+from benchmarks.batching import run_5000
 
 
 # --- check_if_retry_on_failure ---

--- a/benchmarks/web3/test_datastructures_benchmarks.py
+++ b/benchmarks/web3/test_datastructures_benchmarks.py
@@ -1,12 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3.datastructures
-except ImportError:
-    pass
+import web3.datastructures
 
 import faster_web3.datastructures
+from benchmarks.batching import run_100, run_500
 
 # --- Shared parameter sets ---
 init_dicts = [
@@ -56,14 +54,6 @@ onion_ids = ["empty", "callables2", "callables3"]
 
 
 # --- Helpers ---
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
-
-
-def run_500(func, *args, **kwargs):
-    for _ in range(500):
-        func(*args, **kwargs)
 
 
 # --- Benchmarks for ReadableAttributeDict ---

--- a/benchmarks/web3/utils/test_address_benchmarks.py
+++ b/benchmarks/web3/utils/test_address_benchmarks.py
@@ -1,10 +1,7 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3.utils.address
-except ImportError:
-    pass
+import web3.utils.address
 
 import faster_web3.utils.address
 

--- a/benchmarks/web3/utils/test_async_exception_handling_benchmarks.py
+++ b/benchmarks/web3/utils/test_async_exception_handling_benchmarks.py
@@ -3,10 +3,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from unittest.mock import patch, AsyncMock
 
-try:
-    import web3.utils.async_exception_handling
-except ImportError:
-    pass
+import web3.utils.async_exception_handling
 
 import faster_web3.utils.async_exception_handling
 

--- a/benchmarks/web3/utils/test_caching_benchmarks.py
+++ b/benchmarks/web3/utils/test_caching_benchmarks.py
@@ -1,17 +1,10 @@
 import pytest
 from pytest_codspeed import BenchmarkFixture
 
-try:
-    import web3.utils.caching
-except ImportError:
-    pass
+import web3.utils.caching
 
 import faster_web3.utils.caching
-
-
-def run_100(func, *args, **kwargs):
-    for _ in range(100):
-        func(*args, **kwargs)
+from benchmarks.batching import run_100
 
 
 def insert_items(cls, size, keys, values):

--- a/benchmarks/web3/utils/test_exception_handling_benchmarks.py
+++ b/benchmarks/web3/utils/test_exception_handling_benchmarks.py
@@ -2,10 +2,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from unittest.mock import patch
 
-try:
-    import web3.utils.exception_handling
-except ImportError:
-    pass
+import web3.utils.exception_handling
 
 import faster_web3.utils.exception_handling
 


### PR DESCRIPTION
## Summary

Standardize benchmark helper calls around shared literal-count `run_N` wrappers and make the benchmark workflow install the full benchmark dependency set for CodSpeed collection.

## Rationale

The helper functions need to remain the timed wrapper shapes so benchmark timings reflect fixed-count loops directly. The benchmark suite also imports the reference `web3` and `ens` packages during collection, so CodSpeed must install `requirements-benchmark.txt`, not only the CodSpeed plugin requirements.

## Details

- Add shared `run_10`, `run_100`, `run_500`, `run_1000`, `run_5000`, and `run_10000` helpers with explicit literal loop bodies.
- Add matching exception helpers and async helpers without routing through a hidden generic count dispatcher.
- Convert repeated local benchmark helper definitions to import from `benchmarks.batching`.
- Keep direct reference imports in paired benchmarks.
- Update the benchmark workflow so CodSpeed installs `requirements-benchmark.txt`, includes `requirements*.txt` in cache dependency paths, and removes local source packages with `rm -rf faster_web3 faster_ens` before running against the installed wheel.