### PR TITLE
fix(cicd): install benchmark dependencies for CodSpeed

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,28 +3,28 @@ name: Benchmark Suite
 on:
   pull_request:
     branches: [main, master]
-    paths-ignore:
-      - '.circleci/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/benchmark.yaml'
-      - '!.github/workflows/codspeed.yaml'
-      - 'scripts/**'
-      - 'tests/**'
+    paths:
+      - '.github/workflows/benchmark.yaml'
+      - 'faster_web3/**'
+      - 'faster_ens/**'
+      - 'benchmarks/**'
+      - 'scripts/benchmark/**'
+      - 'setup.py'
+      - 'pyproject.toml'
       - 'tox.ini'
-      - '.gitignore'
-      - '*.md'
+      - 'requirements*.txt'
   push:
     branches: [main, master]
-    paths-ignore:
-      - '.circleci/**'
-      - '.github/workflows/**'
-      - '!.github/workflows/benchmark.yaml'
-      - '!.github/workflows/codspeed.yaml'
-      - 'scripts/**'
-      - 'tests/**'
+    paths:
+      - '.github/workflows/benchmark.yaml'
+      - 'faster_web3/**'
+      - 'faster_ens/**'
+      - 'benchmarks/**'
+      - 'scripts/benchmark/**'
+      - 'setup.py'
+      - 'pyproject.toml'
       - 'tox.ini'
-      - '.gitignore'
-      - '*.md'
+      - 'requirements*.txt'
   workflow_dispatch:
     inputs:
       run-type:
@@ -58,12 +58,14 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
             faster_web3/**/*.py
             faster_ens/**/*.py
           pip-cache-dependency-path: |
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
           ccache: true
 
   codspeed-benchmark:
@@ -87,6 +89,7 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
 
       - name: Download wheel
         uses: actions/download-artifact@v8
@@ -94,13 +97,13 @@ jobs:
           name: ${{ needs.build-wheel.outputs.artifact-name }}
           path: .
 
-      - name: Install built wheel and codspeed dependencies
+      - name: Install built wheel and benchmark dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "$(find . -name '*.whl')" -r requirements-codspeed.txt
+          python -m pip install "$(find . -name '*.whl')" -r requirements-benchmark.txt
 
       - name: Remove Python files from test env
-        run: rm -r faster_web3 faster_ens
+        run: rm -rf faster_web3 faster_ens
 
       - name: Run CodSpeed
         uses: CodSpeedHQ/action@v4
@@ -125,6 +128,7 @@ jobs:
             pyproject.toml
             setup.py
             tox.ini
+            requirements*.txt
 
       - name: Download built wheel artifact
         uses: actions/download-artifact@v8
@@ -139,9 +143,7 @@ jobs:
         run: pip install ./*.whl -r requirements-dev.txt -r requirements-benchmark.txt
           
       - name: Remove Python files from test env
-        run: |
-          rm -r faster_web3
-          rm -r faster_ens
+        run: rm -rf faster_web3 faster_ens
           
       - name: Run Pytest Benchmark & Save Output
         run: pytest --benchmark-only --benchmark-json=benchmark.json benchmarks/


### PR DESCRIPTION
## Summary

Install the full benchmark dependency set in the CodSpeed benchmark job so benchmark collection has the reference `web3` and `ens` packages available.

## Rationale

The benchmark suite compares `web3`/`ens` against `faster_web3`/`faster_ens`. `pytest -k "test_faster_" benchmarks/` still imports benchmark modules during collection, so the CodSpeed job must install benchmark dependencies, not only the CodSpeed plugin layer.

## Details

- Change the CodSpeed install step to install the built wheel with `requirements-benchmark.txt`.
- Keep `web3` out of runtime `install_requires`; it remains a benchmark reference dependency.
- Include `requirements*.txt` in benchmark workflow cache dependency paths and the mypycify cache/hash inputs.
- Keep explicit workflow `paths` so benchmark CI only runs when relevant files change.
- Keep source removal as `rm -rf faster_web3 faster_ens` so benchmark smoke runs against the installed wheel artifacts.