### PR TITLE
feat(benchmark): add benchmarks for faster_web3/_utils/decorators.py

### DIFF
--- a/benchmarks/web3/_utils/test_decorators_benchmarks.py
+++ b/benchmarks/web3/_utils/test_decorators_benchmarks.py
@@ -1,0 +1,66 @@
+import warnings
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+try:
+    import web3._utils.decorators
+except ImportError:
+    pass
+
+import faster_web3._utils.decorators
+
+
+def run_10000(fn, *args, **kwargs):
+    for _ in range(10000):
+        fn(*args, **kwargs)
+
+
+def _noop(value):
+    return value
+
+
+# --- reject_recursive_repeats ---
+
+
+@pytest.mark.benchmark(group="reject_recursive_repeats")
+def test_reject_recursive_repeats(benchmark: BenchmarkFixture):
+    @web3._utils.decorators.reject_recursive_repeats
+    def wrapped(value):
+        return value
+
+    benchmark(run_10000, wrapped, 1)
+
+
+@pytest.mark.benchmark(group="reject_recursive_repeats")
+def test_faster_reject_recursive_repeats(benchmark: BenchmarkFixture):
+    @faster_web3._utils.decorators.reject_recursive_repeats
+    def wrapped(value):
+        return value
+
+    benchmark(run_10000, wrapped, 1)
+
+
+# --- deprecated_for ---
+
+
+@pytest.mark.benchmark(group="deprecated_for")
+def test_deprecated_for(benchmark: BenchmarkFixture):
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    @web3._utils.decorators.deprecated_for("use new_func instead")
+    def wrapped(value):
+        return value
+
+    benchmark(run_10000, wrapped, 1)
+
+
+@pytest.mark.benchmark(group="deprecated_for")
+def test_faster_deprecated_for(benchmark: BenchmarkFixture):
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    @faster_web3._utils.decorators.deprecated_for("use new_func instead")
+    def wrapped(value):
+        return value
+
+    benchmark(run_10000, wrapped, 1)


### PR DESCRIPTION
## Summary
Add benchmark coverage for decorator helpers in `web3._utils.decorators` and `faster_web3._utils.decorators`.

## Rationale
Decorator helpers wrap common validation and compatibility paths, so focused coverage helps track overhead from recursion protection and deprecation wrappers.

## Details
Adds paired reference/faster benchmark groups for recursion guard behavior and deprecated wrapper execution. The benchmarks use prebuilt callables and shared fixed-count runners so the timed path stays focused on the decorator behavior.