### PR TITLE
feat(benchmark): add benchmarks for faster_web3/gas_strategies/rpc.py

### DIFF
--- a/benchmarks/web3/gas_strategies/test_rpc_benchmarks.py
+++ b/benchmarks/web3/gas_strategies/test_rpc_benchmarks.py
@@ -1,0 +1,65 @@
+from unittest.mock import (
+    patch,
+)
+
+import pytest
+from pytest_codspeed import (
+    BenchmarkFixture,
+)
+
+import web3.gas_strategies.rpc
+
+import faster_web3.gas_strategies.rpc
+
+from benchmarks.batching import (
+    run_10000,
+)
+from benchmarks.web3.fixtures.core import (
+    EXAMPLE_ADDRESS,
+)
+from benchmarks.web3.fixtures.http import (
+    REQUESTS_SESSION_POST,
+    StaticResponse,
+    make_static_requests_post,
+)
+from benchmarks.web3.fixtures.rpc import (
+    GWEI_RESPONSE_BYTES,
+)
+
+
+TX_CASES = (
+    None,
+    {},
+    {"from": EXAMPLE_ADDRESS, "value": 1},
+)
+
+
+requests_post = make_static_requests_post(StaticResponse(GWEI_RESPONSE_BYTES))
+
+
+@pytest.mark.benchmark(group="rpc_gas_price_strategy")
+@pytest.mark.parametrize("transaction_params", TX_CASES)
+def test_rpc_gas_price_strategy(
+    benchmark: BenchmarkFixture, web3_w3, transaction_params
+):
+    with patch(REQUESTS_SESSION_POST, new=requests_post):
+        benchmark(
+            run_10000,
+            web3.gas_strategies.rpc.rpc_gas_price_strategy,
+            web3_w3,
+            transaction_params,
+        )
+
+
+@pytest.mark.benchmark(group="rpc_gas_price_strategy")
+@pytest.mark.parametrize("transaction_params", TX_CASES)
+def test_faster_rpc_gas_price_strategy(
+    benchmark: BenchmarkFixture, faster_w3, transaction_params
+):
+    with patch(REQUESTS_SESSION_POST, new=requests_post):
+        benchmark(
+            run_10000,
+            faster_web3.gas_strategies.rpc.rpc_gas_price_strategy,
+            faster_w3,
+            transaction_params,
+        )


### PR DESCRIPTION
## Summary
Add benchmark coverage for RPC gas price strategy helpers in `web3.gas_strategies.rpc` and `faster_web3.gas_strategies.rpc`.

## Rationale
RPC gas price strategy calls are part of transaction preparation and depend on provider request plumbing. Paired benchmarks make the strategy overhead visible for the reference and faster implementations.

## Details
Adds symmetric benchmark groups for the RPC gas price strategy path using representative Web3/provider setup and precomputed response behavior. The timed calls focus on the gas price strategy invocation rather than benchmark fixture construction.