### PR TITLE
fix(benchmark): increase iterations for test_utility_methods_benchmarks.py

### DIFF
--- a/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
+++ b/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
@@ -41,37 +41,37 @@ dict_ids = [
 @pytest.mark.benchmark(group="all_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_all_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, web3._utils.utility_methods.all_in_dict, values, d)
+    benchmark(run_5000, web3._utils.utility_methods.all_in_dict, values, d)
 
 
 @pytest.mark.benchmark(group="all_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_faster_all_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, faster_web3._utils.utility_methods.all_in_dict, values, d)
+    benchmark(run_5000, faster_web3._utils.utility_methods.all_in_dict, values, d)
 
 
 @pytest.mark.benchmark(group="any_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_any_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, web3._utils.utility_methods.any_in_dict, values, d)
+    benchmark(run_5000, web3._utils.utility_methods.any_in_dict, values, d)
 
 
 @pytest.mark.benchmark(group="any_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_faster_any_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, faster_web3._utils.utility_methods.any_in_dict, values, d)
+    benchmark(run_5000, faster_web3._utils.utility_methods.any_in_dict, values, d)
 
 
 @pytest.mark.benchmark(group="none_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_none_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, web3._utils.utility_methods.none_in_dict, values, d)
+    benchmark(run_5000, web3._utils.utility_methods.none_in_dict, values, d)
 
 
 @pytest.mark.benchmark(group="none_in_dict")
 @pytest.mark.parametrize("values,d", dict_cases, ids=dict_ids)
 def test_faster_none_in_dict(benchmark: BenchmarkFixture, values, d):
-    benchmark(run_500, faster_web3._utils.utility_methods.none_in_dict, values, d)
+    benchmark(run_5000, faster_web3._utils.utility_methods.none_in_dict, values, d)
 
 
 # Expanded parameterization for set-based function
@@ -102,12 +102,12 @@ set_ids = [
 @pytest.mark.benchmark(group="either_set_is_a_subset")
 @pytest.mark.parametrize("set1,set2", set_cases, ids=set_ids)
 def test_either_set_is_a_subset(benchmark: BenchmarkFixture, set1, set2):
-    benchmark(run_500, web3._utils.utility_methods.either_set_is_a_subset, set1, set2)
+    benchmark(run_5000, web3._utils.utility_methods.either_set_is_a_subset, set1, set2)
 
 
 @pytest.mark.benchmark(group="either_set_is_a_subset")
 @pytest.mark.parametrize("set1,set2", set_cases, ids=set_ids)
 def test_faster_either_set_is_a_subset(benchmark: BenchmarkFixture, set1, set2):
     benchmark(
-        run_500, faster_web3._utils.utility_methods.either_set_is_a_subset, set1, set2
+        run_5000, faster_web3._utils.utility_methods.either_set_is_a_subset, set1, set2
     )

--- a/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
+++ b/benchmarks/web3/_utils/test_utility_methods_benchmarks.py
@@ -9,8 +9,8 @@ except ImportError:
 import faster_web3._utils.utility_methods
 
 
-def run_500(func, *args, **kwargs):
-    for _ in range(500):
+def run_5000(func, *args, **kwargs):
+    for _ in range(5000):
         func(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
Increase iteration counts for the utility methods benchmark suite.

## Rationale
The affected utility method benchmarks were too fast per invocation, which made their measurements noisy and variable. Higher fixed iteration counts give CodSpeed and pytest-benchmark a steadier timing signal.

## Details
Adjusts `test_utility_methods_benchmarks.py` to run the tiny utility methods through larger shared fixed-count batches. The change is benchmark-harness-only and does not alter library behavior.