### PR TITLE
feat(cicd): centralize pytest config

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -100,9 +100,11 @@ jobs:
 
       - name: Run CodSpeed
         uses: CodSpeedHQ/action@v4
+        env:
+          PYTEST_ADDOPTS: "-c benchmarks/pytest-codspeed.ini --test-group=${{ matrix.shard }}"
         with:
           mode: instrumentation
-          run: pytest --codspeed -k "test_faster_" --test-group=${{ matrix.shard }} --test-group-count=10 benchmarks/
+          run: pytest
 
   comparison-benchmark:
     name: Run Comparison Benchmarks
@@ -140,7 +142,9 @@ jobs:
           rm -r faster_ens
           
       - name: Run Pytest Benchmark & Save Output
-        run: pytest --benchmark-only --benchmark-json=benchmark.json benchmarks/
+        env:
+          PYTEST_ADDOPTS: "-c benchmarks/pytest-benchmark.ini"
+        run: pytest
         
       - name: Upload Pytest Benchmark Results
         uses: actions/upload-artifact@v6

--- a/benchmarks/pytest-benchmark.ini
+++ b/benchmarks/pytest-benchmark.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --benchmark-only --benchmark-json=benchmark.json
+testpaths =
+    benchmarks

--- a/benchmarks/pytest-codspeed.ini
+++ b/benchmarks/pytest-codspeed.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --codspeed -k "test_faster_" --test-group-count=10
+testpaths =
+    benchmarks


### PR DESCRIPTION
## Summary
- move pytest CLI args into config files
- keep workflows invoking pytest without inline args

## Manual testing
- [ ] not run (not requested)
