### PR TITLE
fix(cicd): maximize release wheel compatibility and validate release workflow changes on PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
       - master
     types: [published]
   workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yaml"
 
 jobs:
   build_wheels:
@@ -25,6 +28,15 @@ jobs:
             artifact_name: "wheels-ubuntu-latest-manylinux-x64"
 
           # ----------------------------------------------------
+          # manylinux arm64
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-arm64
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: aarch64
+            artifact_name: "wheels-ubuntu-latest-manylinux-arm64"
+
+          # ----------------------------------------------------
           # manylinux 32-bit
           # ----------------------------------------------------
           - os: ubuntu-latest
@@ -32,6 +44,42 @@ jobs:
             cibw_build: "*manylinux*"
             cibw_archs_linux: i686
             artifact_name: "wheels-ubuntu-latest-manylinux-x86"
+
+          # ----------------------------------------------------
+          # manylinux ppc64le
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-ppc64le
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: ppc64le
+            artifact_name: "wheels-ubuntu-latest-manylinux-ppc64le"
+
+          # ----------------------------------------------------
+          # manylinux s390x
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-s390x
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: s390x
+            artifact_name: "wheels-ubuntu-latest-manylinux-s390x"
+
+          # ----------------------------------------------------
+          # manylinux armv7l
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-armv7l
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: armv7l
+            artifact_name: "wheels-ubuntu-latest-manylinux-armv7l"
+
+          # ----------------------------------------------------
+          # manylinux riscv64
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-riscv64
+            cibw_build: "*manylinux*"
+            cibw_archs_linux: riscv64
+            artifact_name: "wheels-ubuntu-latest-manylinux-riscv64"
 
           # ----------------------------------------------------
           # musllinux 64-bit
@@ -43,6 +91,15 @@ jobs:
             artifact_name: "wheels-ubuntu-latest-musllinux-x64"
 
           # ----------------------------------------------------
+          # musllinux arm64
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-arm64
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: aarch64
+            artifact_name: "wheels-ubuntu-latest-musllinux-arm64"
+
+          # ----------------------------------------------------
           # musllinux 32-bit
           # ----------------------------------------------------
           - os: ubuntu-latest
@@ -52,13 +109,60 @@ jobs:
             artifact_name: "wheels-ubuntu-latest-musllinux-x86"
 
           # ----------------------------------------------------
-          # macOS (64-bit only)
+          # musllinux ppc64le
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-ppc64le
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: ppc64le
+            artifact_name: "wheels-ubuntu-latest-musllinux-ppc64le"
+
+          # ----------------------------------------------------
+          # musllinux s390x
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-s390x
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: s390x
+            artifact_name: "wheels-ubuntu-latest-musllinux-s390x"
+
+          # ----------------------------------------------------
+          # musllinux armv7l
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-armv7l
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: armv7l
+            artifact_name: "wheels-ubuntu-latest-musllinux-armv7l"
+
+          # ----------------------------------------------------
+          # musllinux riscv64
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-riscv64
+            cibw_build: "*musllinux*"
+            cibw_archs_linux: riscv64
+            artifact_name: "wheels-ubuntu-latest-musllinux-riscv64"
+
+          # ----------------------------------------------------
+          # macOS 64-bit (x86_64)
           # ----------------------------------------------------
           - os: macos-latest
-            build_type: macos
+            build_type: macos-x64
             cibw_build: ""
             cibw_archs_linux: ""
-            artifact_name: "wheels-macos-latest"
+            cibw_archs_macos: x86_64
+            artifact_name: "wheels-macos-latest-x64"
+
+          # ----------------------------------------------------
+          # macOS arm64
+          # ----------------------------------------------------
+          - os: macos-latest
+            build_type: macos-arm64
+            cibw_build: ""
+            cibw_archs_linux: ""
+            cibw_archs_macos: arm64
+            artifact_name: "wheels-macos-latest-arm64"
 
           # ----------------------------------------------------
           # Windows 64-bit
@@ -68,6 +172,15 @@ jobs:
             cibw_build: ""
             cibw_archs_windows: AMD64
             artifact_name: "wheels-windows-latest-x64"
+
+          # ----------------------------------------------------
+          # Windows arm64
+          # ----------------------------------------------------
+          - os: windows-latest
+            build_type: winarm64
+            cibw_build: ""
+            cibw_archs_windows: ARM64
+            artifact_name: "wheels-windows-latest-arm64"
 
           # ----------------------------------------------------
           # Windows 32-bit
@@ -90,10 +203,16 @@ jobs:
           python-version: "3.11"
           cache: pip
 
+      - name: Enable QEMU for Linux emulated wheel builds
+        if: runner.os == 'Linux' && (matrix.cibw_archs_linux == 'aarch64' || matrix.cibw_archs_linux == 'ppc64le' || matrix.cibw_archs_linux == 's390x' || matrix.cibw_archs_linux == 'armv7l' || matrix.cibw_archs_linux == 'riscv64')
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64,ppc64le,s390x,arm,riscv64
+
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip setuptools wheel cibuildwheel
-          
+
       - name: Cache .mypy_cache
         uses: actions/cache@v5
         with:
@@ -106,13 +225,14 @@ jobs:
           CIBW_SKIP: pp*
           # On Linux: manylinux / musllinux arches
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || '' }}
-          # On Windows: AMD64 / x86
+          # On Windows: AMD64 / ARM64 / x86
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows || '' }}
+          # On macOS: x86_64 / arm64
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos || '' }}
           # Which wheels to build for Linux (manylinux vs. musllinux)
           CIBW_BUILD: ${{ matrix.cibw_build || '' }}
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-        continue-on-error: true
 
       - name: Upload wheels
         uses: actions/upload-artifact@v6
@@ -123,6 +243,7 @@ jobs:
   publish_sdist_and_wheels:
     name: Publish wheels to PyPI
     needs: build_wheels
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -147,10 +268,10 @@ jobs:
 
       - name: Drop build folder to prevent shadowing issues w/ the PyPA “build” module
         run: rm -rf build
-      
+
       - name: Install PyPA “build” module
         run: pip install -U build
-      
+
       - name: Build sdist
         run: python -m build --sdist
 
@@ -163,11 +284,41 @@ jobs:
           name: "wheels-ubuntu-latest-manylinux-x64"
           path: wheelhouse/linux-many-x64
 
+      - name: Download manylinux arm64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-manylinux-arm64"
+          path: wheelhouse/linux-many-arm64
+
       - name: Download manylinux 32-bit wheels
         uses: actions/download-artifact@v7
         with:
           name: "wheels-ubuntu-latest-manylinux-x86"
           path: wheelhouse/linux-many-x86
+
+      - name: Download manylinux ppc64le wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-manylinux-ppc64le"
+          path: wheelhouse/linux-many-ppc64le
+
+      - name: Download manylinux s390x wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-manylinux-s390x"
+          path: wheelhouse/linux-many-s390x
+
+      - name: Download manylinux armv7l wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-manylinux-armv7l"
+          path: wheelhouse/linux-many-armv7l
+
+      - name: Download manylinux riscv64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-manylinux-riscv64"
+          path: wheelhouse/linux-many-riscv64
 
       - name: Download musllinux 64-bit wheels
         uses: actions/download-artifact@v7
@@ -175,17 +326,53 @@ jobs:
           name: "wheels-ubuntu-latest-musllinux-x64"
           path: wheelhouse/linux-musl-x64
 
+      - name: Download musllinux arm64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-musllinux-arm64"
+          path: wheelhouse/linux-musl-arm64
+
       - name: Download musllinux 32-bit wheels
         uses: actions/download-artifact@v7
         with:
           name: "wheels-ubuntu-latest-musllinux-x86"
           path: wheelhouse/linux-musl-x86
 
-      - name: Download macOS wheels
+      - name: Download musllinux ppc64le wheels
         uses: actions/download-artifact@v7
         with:
-          name: "wheels-macos-latest"
-          path: wheelhouse/macos
+          name: "wheels-ubuntu-latest-musllinux-ppc64le"
+          path: wheelhouse/linux-musl-ppc64le
+
+      - name: Download musllinux s390x wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-musllinux-s390x"
+          path: wheelhouse/linux-musl-s390x
+
+      - name: Download musllinux armv7l wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-musllinux-armv7l"
+          path: wheelhouse/linux-musl-armv7l
+
+      - name: Download musllinux riscv64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-ubuntu-latest-musllinux-riscv64"
+          path: wheelhouse/linux-musl-riscv64
+
+      - name: Download macOS x86_64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-macos-latest-x64"
+          path: wheelhouse/macos-x64
+
+      - name: Download macOS arm64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-macos-latest-arm64"
+          path: wheelhouse/macos-arm64
 
       - name: Download Windows 64-bit wheels
         uses: actions/download-artifact@v7
@@ -193,18 +380,22 @@ jobs:
           name: "wheels-windows-latest-x64"
           path: wheelhouse/windows-x64
 
+      - name: Download Windows arm64 wheels
+        uses: actions/download-artifact@v7
+        with:
+          name: "wheels-windows-latest-arm64"
+          path: wheelhouse/windows-arm64
+
       - name: Download Windows 32-bit wheels
         uses: actions/download-artifact@v7
         with:
           name: "wheels-windows-latest-x86"
           path: wheelhouse/windows-x86
-        continue-on-error: true
 
       # ----------------------------------------------------
       # Publish all built artifacts to PyPI
       # ----------------------------------------------------
       - name: Publish sdist and wheels to PyPI
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## Summary
- Expand release wheel build/publish coverage across additional Linux architectures, macOS arm64, and Windows arm64.
- Add PR-scoped validation trigger for `release.yaml` changes.
- Guard publish job so uploads only run on `release.published` events.

## Rationale
- Broader wheel coverage reduces install failures on non-x86 and alternative distro targets.
- Running the release workflow on PRs catches workflow regressions earlier.
- Explicit publish gating prevents accidental publish behavior during non-release validation runs.

## Details
- Added matrix entries for:
  - manylinux: `aarch64`, `ppc64le`, `s390x`, `armv7l`, `riscv64`
  - musllinux: `aarch64`, `ppc64le`, `s390x`, `armv7l`, `riscv64`
  - macOS: split into `x86_64` and `arm64`
  - Windows: added `ARM64`
- Added QEMU setup for emulated Linux arch wheel builds.
- Added `CIBW_ARCHS_MACOS` wiring.
- Added artifact download coverage for all newly introduced targets.
- Added workflow trigger:
  - `pull_request` with `paths: [.github/workflows/release.yaml]`
- Added publish job condition:
  - `if: github.event_name == 'release' && github.event.action == 'published'`

Validation executed:
- YAML parse check for updated release workflow content.
- `pip check` in local environment.