### PR TITLE
fix(benchmark): clear codspeed deprecation warning

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Run CodSpeed
         uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: simulation
           run: pytest --codspeed -k "test_faster_" --test-group=${{ matrix.shard }} --test-group-count=10 benchmarks/
 
   comparison-benchmark:


### PR DESCRIPTION
## Summary
Update the benchmark workflow to use CodSpeed simulation mode.

## Rationale
The previous CodSpeed `instrumentation` mode emitted a deprecation warning during benchmark runs. Switching to the supported mode keeps benchmark CI output clean without changing which benchmarks run.

## Details
Changes the benchmark workflow's CodSpeed action configuration from `mode: instrumentation` to `mode: simulation` for the faster benchmark job. The pytest command and benchmark selection remain unchanged.