### PR TITLE
fix: remove deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
- Remove the deprecated MIT license Trove classifier from `setup.py`.
- Keep the existing SPDX-compatible `license="MIT"` metadata unchanged.

## Rationale
Modern setuptools warns that license classifiers should be removed in favor of SPDX license expressions. This avoids that packaging warning without changing package behavior.

## Details
- Removed `License :: OSI Approved :: MIT License` from `classifiers`.
- Did not change package versions, dependencies, lockfiles, generated files, or compiled sources.
- Validation:
  - `rg -n "License :: OSI Approved :: MIT License" setup.py pyproject.toml`
  - `python setup.py egg_info --egg-base /tmp/faster-web3-egg-info`
  - `git diff --check origin/master..HEAD`