### PR TITLE
fix(cicd): repair wheel matrix install checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ common: &common
         command: |
           python -m pip install --upgrade pip
           python -m pip install tox
-          python web3/scripts/install_pre_releases.py
+          python faster_web3/scripts/install_pre_releases.py
     - run:
         name: run tox
         command: python -m tox run -r
@@ -75,7 +75,7 @@ geth_steps: &geth_steps
               sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
               sudo apt-get update
               sudo apt-get install -y build-essential
-              pygeth_version=$(python web3/scripts/parse_pygeth_version.py)
+              pygeth_version=$(python faster_web3/scripts/parse_pygeth_version.py)
               echo "installing py-geth$pygeth_version"
               pip install -U --user "py-geth$pygeth_version"
               python -m geth.install v<< pipeline.parameters.geth_version >>

--- a/faster_web3/scripts/release/test_wheel_install.sh
+++ b/faster_web3/scripts/release/test_wheel_install.sh
@@ -3,7 +3,24 @@
 set -euo pipefail
 
 repo_dir="$(pwd)"
-wheel_path="$(find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit)"
+
+find_wheel() {
+    if [ ! -d "$repo_dir/dist" ]; then
+        return 0
+    fi
+
+    find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit
+}
+
+wheel_path="$(find_wheel)"
+
+# GitHub Actions downloads the mypycified wheel into dist before tox runs, while
+# CircleCI starts from a checkout with no wheel artifact, so only build locally
+# when the artifact branch is not available.
+if [ -z "$wheel_path" ]; then
+    python -m build --wheel
+    wheel_path="$(find_wheel)"
+fi
 
 if [ -z "$wheel_path" ]; then
     echo "No faster_web3 wheel found in $repo_dir/dist" >&2
@@ -15,6 +32,7 @@ python -m venv "$temp_dir/venv-test"
 source "$temp_dir/venv-test/bin/activate"
 python -m pip install --upgrade pip
 python -m pip install --upgrade "$wheel_path"
+cd "$temp_dir"
 python - <<'PY'
 from faster_web3 import Web3
 import faster_web3._utils.method_formatters as method_formatters

--- a/faster_web3/scripts/release/test_wheel_install.sh
+++ b/faster_web3/scripts/release/test_wheel_install.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
-set -e
-rm -rf build dist
-python -m build
-cd $(mktemp -d)
-python -m venv venv-test
-source venv-test/bin/activate
-pip install --upgrade "$(ls ~/repo/dist/web3-*-py3-none-any.whl)"
-python -c "import web3"
+set -euo pipefail
+
+repo_dir="$(pwd)"
+wheel_path="$(find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit)"
+
+if [ -z "$wheel_path" ]; then
+    echo "No faster_web3 wheel found in $repo_dir/dist" >&2
+    exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+python -m venv "$temp_dir/venv-test"
+source "$temp_dir/venv-test/bin/activate"
+python -m pip install --upgrade pip
+python -m pip install --upgrade "$wheel_path"
+python - <<'PY'
+from faster_web3 import Web3
+import faster_web3._utils.method_formatters as method_formatters
+
+compiled_path = method_formatters.__file__
+assert compiled_path.endswith((".so", ".pyd")), compiled_path
+print(Web3)
+print(compiled_path)
+PY

--- a/faster_web3/scripts/release/test_windows_wheel_install.sh
+++ b/faster_web3/scripts/release/test_windows_wheel_install.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
+set -euo pipefail
+
 python --version
-bash.exe -c "set -e"
-bash.exe -c "rm -rf build dist"
-python -m build
-bash.exe -c "export temp_dir=$(mktemp -d)"
-cd $temp_dir
-python -m venv venv-test
-bash.exe -c "source venv-test/Scripts/activate"
-bash.exe -c 'python -m pip install --upgrade "$(ls /c/Users/circleci/project/web3.py/dist/web3-*-py3-none-any.whl)" --progress-bar off'
-python -c "from faster_web3 import Web3"
+
+repo_dir="$(pwd)"
+wheel_path="$(find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit)"
+
+if [ -z "$wheel_path" ]; then
+    echo "No faster_web3 wheel found in $repo_dir/dist" >&2
+    exit 1
+fi
+
+temp_dir="$(mktemp -d)"
+python -m venv "$temp_dir/venv-test"
+source "$temp_dir/venv-test/Scripts/activate"
+python -m pip install --upgrade pip
+python -m pip install --upgrade "$wheel_path" --progress-bar off
+python - <<'PY'
+from faster_web3 import Web3
+import faster_web3._utils.method_formatters as method_formatters
+
+compiled_path = method_formatters.__file__
+assert compiled_path.endswith(".pyd"), compiled_path
+print(Web3)
+print(compiled_path)
+PY

--- a/faster_web3/scripts/release/test_windows_wheel_install.sh
+++ b/faster_web3/scripts/release/test_windows_wheel_install.sh
@@ -5,7 +5,24 @@ set -euo pipefail
 python --version
 
 repo_dir="$(pwd)"
-wheel_path="$(find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit)"
+
+find_wheel() {
+    if [ ! -d "$repo_dir/dist" ]; then
+        return 0
+    fi
+
+    find "$repo_dir/dist" -name 'faster_web3-*.whl' -print -quit
+}
+
+wheel_path="$(find_wheel)"
+
+# GitHub Actions downloads the mypycified wheel into dist before tox runs, while
+# CircleCI starts from a checkout with no wheel artifact, so only build locally
+# when the artifact branch is not available.
+if [ -z "$wheel_path" ]; then
+    python -m build --wheel
+    wheel_path="$(find_wheel)"
+fi
 
 if [ -z "$wheel_path" ]; then
     echo "No faster_web3 wheel found in $repo_dir/dist" >&2
@@ -17,6 +34,7 @@ python -m venv "$temp_dir/venv-test"
 source "$temp_dir/venv-test/Scripts/activate"
 python -m pip install --upgrade pip
 python -m pip install --upgrade "$wheel_path" --progress-bar off
+cd "$temp_dir"
 python - <<'PY'
 from faster_web3 import Web3
 import faster_web3._utils.method_formatters as method_formatters

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ allowlist_externals=
     /bin/rm
     /bin/bash
 commands=
-    /bin/bash {toxinidir}/web3/scripts/release/test_wheel_install.sh
+    /bin/bash {toxinidir}/faster_web3/scripts/release/test_wheel_install.sh
 skip_install=true
 
 [testenv:windows-wheel]
@@ -85,5 +85,5 @@ deps=
 allowlist_externals=
     bash.exe
 commands=
-    bash.exe {toxinidir}/web3/scripts/release/test_windows_wheel_install.sh
+    bash.exe {toxinidir}/faster_web3/scripts/release/test_windows_wheel_install.sh
 skip_install=true


### PR DESCRIPTION
## Summary
fix wheel test script paths and wheel name assumptions.

## Rationale
wheel jobs currently fail before validating the compiled wheel artifact.

## Details
tox now invokes existing faster_web3 scripts; scripts install `faster_web3` wheels and verify compiled import.

## Validation
- `git diff --check` passed locally.
- Local wheel tox validation was not run to completion because local publishing was prioritized after `git push` authentication failed; CI should exercise the updated wheel matrix.