### PR TITLE
fix(cicd): skip unsupported Windows free-threaded jobs

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyminor: ["10", "11", "12", "13", "13t", "14", "14t"]
+        pyminor: ["10", "11", "12", "13", "14"]
       # limit parallelism for cronjob, otherwise blast it
       max-parallel: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 2 || 1000 }}
     outputs:
@@ -124,6 +124,11 @@ jobs:
         jobtype: [core, ens, integration-ethtester, lint, wheel]
         os: [ubuntu-latest, macos-latest, windows-latest]
         pyminor: ["10", "11", "12", "13", "13t", "14", "14t"]
+        exclude:
+          - os: windows-latest
+            pyminor: "13t"
+          - os: windows-latest
+            pyminor: "14t"
       # limit parallelism for cronjob, otherwise blast it
       max-parallel: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 4 || 1000 }}
     env:


### PR DESCRIPTION
## Summary
Remove Windows free-threaded `3.13t` and `3.14t` jobs from the Tox build/test matrix.

## Rationale
Windows free-threaded ENS/integration jobs currently fail while installing `pywin32` because no matching distribution is available for that interpreter combination.

## Details
- Windows wheel builds now cover only non-free-threaded Python versions.
- The Tox matrix excludes `windows-latest` for `3.13t` and `3.14t` across job types.
- Ubuntu and macOS free-threaded jobs are left intact.

## Validation
- `pre-commit run check-yaml --files .github/workflows/tox.yaml`
- `git diff --check`