### PR TITLE
fix(test): compact ENSIP-15 pytest IDs for Windows CI

### DIFF
--- a/tests/ens/normalization/test_normalize_name_ensip15.py
+++ b/tests/ens/normalization/test_normalize_name_ensip15.py
@@ -1,4 +1,5 @@
 import pytest
+import hashlib
 import json
 import os
 
@@ -24,10 +25,22 @@ if not len(POSITIVE_TEST_CASES) + len(NEGATIVE_TEST_CASES) == len(normalization_
     raise AssertionError("Not all normalization tests are accounted for.")
 
 
+def _case_ids(prefix, test_cases):
+    # Keep pytest node IDs compact: some ENSIP-15 names are longer than Windows'
+    # environment variable limit once pytest/flaky mirrors node IDs during setup.
+    return [
+        (
+            f"{prefix}-{index:05d}-"
+            f"{hashlib.sha1(test_case['name'].encode('utf-8')).hexdigest()[:8]}"
+        )
+        for index, test_case in enumerate(test_cases)
+    ]
+
+
 @pytest.mark.parametrize(
     "positive_test_case",
     POSITIVE_TEST_CASES,
-    ids=lambda t: t["name"],
+    ids=_case_ids("positive", POSITIVE_TEST_CASES),
 )
 def test_normalize_name_ensip15_positive_test_cases(positive_test_case):
     name = positive_test_case["name"]
@@ -39,7 +52,7 @@ def test_normalize_name_ensip15_positive_test_cases(positive_test_case):
 @pytest.mark.parametrize(
     "negative_test_case",
     NEGATIVE_TEST_CASES,
-    ids=lambda t: t["name"],
+    ids=_case_ids("negative", NEGATIVE_TEST_CASES),
 )
 def test_normalize_name_ensip15_negative_test_cases(negative_test_case):
     name = negative_test_case["name"]


### PR DESCRIPTION
## Summary
- Replace raw ENSIP-15 fixture names as pytest param IDs with compact deterministic IDs.
- Keep the full ENSIP-15 fixture data and assertions unchanged.

## Rationale
Windows rejects environment variables longer than 32767 characters. One ENSIP-15 negative fixture has a 33792-character name, and pytest/flaky can mirror the full node ID during setup/teardown. Compact IDs prevent that Windows-only CI failure while still running every case.

## Details
- Add `_case_ids()` to generate IDs like `negative-08118-6090bbd8` from the case index and a short SHA-1 hash of the original name.
- Apply the compact IDs to both positive and negative ENSIP-15 parametrizations.
- Confirmed the compiled editable install imports `.so` modules for `faster_ens._normalization` and `faster_web3._utils.method_formatters`.

## Validation
- `python3 -m compileall -q tests/ens/normalization/test_normalize_name_ensip15.py`
- Generated ID sanity check: raw max name length `33792`, generated max ID length `23`
- Compiled editable install: `python -m pip install -e '.[test]'`
- `python -m pytest tests/ens/normalization/test_normalize_name_ensip15.py --collect-only -q` via captured output: `38229` node IDs, longest full node ID `128`
- `python -m pytest tests/ens/normalization/test_normalize_name_ensip15.py -q -n auto --maxprocesses=15`: `38229 passed`
- `git diff --check`

Note: I also tried the full local `tests/ens` command. The ENSIP-15 portion passed, but the non-normalization subset hit an unrelated sandbox/DNS failure in `tests/ens/test_offchain_resolution.py::test_async_offchain_resolution_with_post_request` while resolving `web3.py`.