### PR TITLE
fix(core): preserve subscription context fields

### DIFF
--- a/build/__native_5f8b22f5f815a3776376.c
+++ b/build/__native_5f8b22f5f815a3776376.c
@@ -109730,7 +109730,7 @@ CPyL54: ;
     goto CPyL81;
 CPyL55: ;
     cpy_r_r61 = 0;
-    cpy_r_r62 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* frozenset({'syncing', 'status'}) */
+    cpy_r_r62 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* frozenset({'status', 'syncing'}) */
     cpy_r_r63 = PyObject_GetIter(cpy_r_r62);
     if (unlikely(cpy_r_r63 == NULL)) {
         CPy_AddTraceback("faster_web3/_utils/method_formatters.py", "subscription_formatter", DIFFCHECK_PLACEHOLDER, CPyStatic_method_formatters___globals);
@@ -290670,7 +290670,7 @@ const char * const CPyLit_Str[] = {
     "\003\beth_sign\021eth_signTypedData$RPC_METHODS_UNSUPPORTED_DURING_BATCH",
     "\004\033faster_web3._utils.batching\004web3\016_requests_info\024_async_requests_info",
     "\004\016RequestBatcher\ais_text\bis_bytes\alatin-1",
-    "\005\036unrecognized block reference: \rWeb3TypeError\bearliest\tfinalized\004safe",
+    "\005\036unrecognized block reference: \rWeb3TypeError\004safe\tfinalized\bearliest",
     "\002\tis_string\006is_hex",
     "\001=Value did not match any of the recognized block identifiers: ",
     "\004\tTypeGuard\021typing_extensions\023ASYNC_PROVIDER_TYPE\022SYNC_PROVIDER_TYPE",
@@ -290833,7 +290833,7 @@ const char * const CPyLit_Str[] = {
     "\002)Storage key must be a 32-byte value, got \017variable_length",
     "\005\023to_checksum_address\abalance\astorage\nis_address\022apply_formatter_if",
     "\003\021has_pretrace_keys#type_aware_apply_formatters_to_dict\tis_hexstr",
-    "\005\asyncing\006status\017Block with id: \v not found.\nIndexError",
+    "\005\006status\asyncing\017Block with id: \v not found.\nIndexError",
     "\003\030Unknown block identifier\020Uncle at index: \023 of block with id: ",
     "\002\'Unknown block identifier or uncle index\027Transaction with hash: ",
     "\003\030Unknown transaction hash\023TransactionNotFound\023Transaction index: ",
@@ -291320,8 +291320,8 @@ const int CPyLit_Tuple[] = {
     72, 73, 365, 75, 77, 79, 521, 81, 1, 802
 };
 const int CPyLit_FrozenSet[] = {
-    4, 5, 393, 394, 295, 307, 395, 3, 19, 1945, 0, 2, 896, 897, 4, 378,
-    1094, 1095, 1092
+    4, 5, 307, 393, 394, 395, 295, 3, 19, 1945, 0, 2, 896, 897, 4, 1094,
+    1092, 378, 1095
 };
 CPyModule *CPyModule_faster_ens__internal = NULL;
 CPyModule *CPyModule_faster_ens;

--- a/faster_web3/utils/subscriptions.py
+++ b/faster_web3/utils/subscriptions.py
@@ -62,7 +62,7 @@ class EthSubscriptionContext(Generic[TSubscription, TSubscriptionResult]):
         self.async_w3: Final = async_w3
         self.subscription: Final = subscription
         self.result: Final = result
-        self.__dict__: Final = kwargs
+        self.__dict__.update(kwargs)
 
     def __getattr__(self, item: str) -> Any:
         if item in self.__dict__:


### PR DESCRIPTION
## Summary
- Preserve the built-in `EthSubscriptionContext` fields while adding custom handler context kwargs.
- Keep the change scoped to `faster_web3/utils/subscriptions.py`.

## Rationale
`EthSubscriptionContext.__init__` assigned `self.__dict__` directly to the kwargs dict, which replaced the fields set immediately before it. Subscription handlers should be able to access `async_w3`, `subscription`, `result`, and any custom handler context values, matching the web3.py interface behavior.

## Details
- Replace the direct `self.__dict__ = kwargs` assignment with `self.__dict__.update(kwargs)`.
- This PR intentionally does not make `subscriptions.py` mypyc-compiled; that remains separate future work.
- CI is expected to remain red from unrelated core/lint/wheel issues.

## Testing
- `python -m pytest tests/core/subscriptions/test_subscription_manager.py -q` passed: 15 passed.
- Runtime smoke check confirmed `EthSubscriptionContext("w3", "sub", "result", counter=1)` exposes `async_w3`, `subscription`, `result`, and `counter`.
- Confirmed `faster_web3/utils/subscriptions.py` still imports as `.py`.
- `git diff --check` passed.