### PR TITLE
fix(cicd): route Windows wheel checks through Windows tox env

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -132,7 +132,7 @@ jobs:
       # limit parallelism for cronjob, otherwise blast it
       max-parallel: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 4 || 1000 }}
     env:
-      TOXENV: py3${{ matrix.pyminor }}-${{ matrix.jobtype }}
+      TOXENV: ${{ matrix.os == 'windows-latest' && matrix.jobtype == 'wheel' && 'windows-wheel' || format('py3{0}-{1}', matrix.pyminor, matrix.jobtype) }}
       TOX_RECREATE_FLAG: ${{ github.event_name == 'schedule' && '-r' || '' }}
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
Route Windows wheel test matrix rows to the existing `windows-wheel` tox environment.

## Rationale
Windows wheel checks were still using `py3xx-wheel`, which invokes `/bin/bash` and fails with `[WinError 2]` before validating the downloaded compiled wheel artifact.

## Details
- Keep the Python-versioned wheel artifact download unchanged for Windows wheel jobs.
- Use `windows-wheel` only when `matrix.os == 'windows-latest'` and `matrix.jobtype == 'wheel'`.
- Leave all non-Windows wheel checks and non-wheel tox jobs on their existing `py3${{ matrix.pyminor }}-${{ matrix.jobtype }}` tox envs.

## Validation
- `git diff --check` passed locally.
- Commit hook YAML checks passed locally, but the full hook suite could not complete because `mypy-local` could not find `python` in this environment and `blocklint` flagged existing `master` strings in the workflow trigger.
- Full validation requires GitHub Actions because this failure path is Windows-runner-specific.