### PR TITLE
fix(cicd): run tox tests against installed wheels

### DIFF
--- a/scripts/pytest_installed_wheel.py
+++ b/scripts/pytest_installed_wheel.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import argparse
+import importlib
+import importlib.machinery
+import pathlib
+import sys
+
+
+DEFAULT_PACKAGES = ("faster_web3", "faster_ens")
+DEFAULT_COMPILED_MODULES = ("faster_web3._utils.method_formatters",)
+
+
+def _resolve_path_entry(path_entry: str) -> pathlib.Path:
+    if path_entry:
+        return pathlib.Path(path_entry).resolve(strict=False)
+    return pathlib.Path.cwd().resolve(strict=False)
+
+
+def _remove_repo_root_from_sys_path(repo_root: pathlib.Path) -> None:
+    sys.path[:] = [
+        path_entry
+        for path_entry in sys.path
+        if _resolve_path_entry(path_entry) != repo_root
+    ]
+
+
+def _module_path(module_name: str) -> pathlib.Path:
+    module = importlib.import_module(module_name)
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        raise RuntimeError(f"{module_name} has no __file__; cannot verify import path")
+    return pathlib.Path(module_file).resolve(strict=False)
+
+
+def _is_relative_to(path: pathlib.Path, parent: pathlib.Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _source_root(module_name: str, repo_root: pathlib.Path) -> pathlib.Path:
+    return repo_root / module_name.split(".", 1)[0]
+
+
+def _assert_installed(module_name: str, repo_root: pathlib.Path) -> pathlib.Path:
+    module_path = _module_path(module_name)
+    if _is_relative_to(module_path, _source_root(module_name, repo_root)):
+        raise RuntimeError(
+            f"{module_name} imported from source checkout at {module_path}; "
+            "expected the installed wheel"
+        )
+    return module_path
+
+
+def _assert_compiled(module_name: str, repo_root: pathlib.Path) -> None:
+    module_path = _assert_installed(module_name, repo_root)
+    if not any(
+        str(module_path).endswith(suffix)
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES
+    ):
+        raise RuntimeError(
+            f"{module_name} imported from {module_path}; expected a compiled extension"
+        )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--package", action="append", dest="packages")
+    parser.add_argument(
+        "--compiled-module",
+        action="append",
+        dest="compiled_modules",
+    )
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.pytest_args[:1] == ["--"]:
+        args.pytest_args = args.pytest_args[1:]
+    if not args.pytest_args:
+        parser.error("pytest arguments are required after --")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = pathlib.Path(args.repo_root).resolve(strict=False)
+
+    _remove_repo_root_from_sys_path(repo_root)
+
+    for package in args.packages or DEFAULT_PACKAGES:
+        _assert_installed(package, repo_root)
+
+    for module_name in args.compiled_modules or DEFAULT_COMPILED_MODULES:
+        _assert_compiled(module_name, repo_root)
+
+    sys.path.append(str(repo_root))
+
+    import pytest
+
+    return pytest.main(["--import-mode=importlib", *args.pytest_args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -17,24 +17,25 @@ max_issue_threshold=1
 
 [testenv]
 allowlist_externals=make,pre-commit
+changedir={envtmpdir}
 install_command=python -m pip install {opts} {packages}
-usedevelop=True
+package=wheel
 extras = test
 commands=
-    core: pytest {posargs:tests/core -n auto --maxprocesses=15}
-    core_sync: pytest {posargs:tests/core -m "not asyncio" -n auto --maxprocesses=15}
-    core_async: pytest {posargs:tests/core -m asyncio -n auto --maxprocesses=15}
-    ens: pytest {posargs:tests/ens -n auto --maxprocesses=15}
-    ens-lite: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py -n auto --maxprocesses=15}
-    ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q -n auto --maxprocesses=15}
-    integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py -k "not Async" -n auto --maxprocesses=15}
-    integration-goethereum-ipc_async: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py -k Async -n auto --maxprocesses=15}
-    integration-goethereum-http: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k "not Async" -n auto --maxprocesses=15}
-    integration-goethereum-http_async: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k Async -n auto --maxprocesses=15}
-    integration-goethereum-legacy_ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_legacy_ws.py -n auto --maxprocesses=15}
-    integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws -n auto --maxprocesses=15}
-    integration-goethereum: pytest {posargs:tests/integration/go_ethereum -n auto --maxprocesses=15}
-    integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py -n auto --maxprocesses=15}
+    core: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/core -n auto --maxprocesses=15}
+    core_sync: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/core -m "not asyncio" -n auto --maxprocesses=15}
+    core_async: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/core -m asyncio -n auto --maxprocesses=15}
+    ens: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/ens -n auto --maxprocesses=15}
+    ens-lite: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/ens --ignore={toxinidir}/tests/ens/normalization/test_normalize_name_ensip15.py -n auto --maxprocesses=15}
+    ensip15: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/ens/normalization/test_normalize_name_ensip15.py -q -n auto --maxprocesses=15}
+    integration-goethereum-ipc: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_ipc.py -k "not Async" -n auto --maxprocesses=15}
+    integration-goethereum-ipc_async: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_ipc.py -k Async -n auto --maxprocesses=15}
+    integration-goethereum-http: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_http.py -k "not Async" -n auto --maxprocesses=15}
+    integration-goethereum-http_async: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_http.py -k Async -n auto --maxprocesses=15}
+    integration-goethereum-legacy_ws: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_legacy_ws.py -n auto --maxprocesses=15}
+    integration-goethereum-ws: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum/test_goethereum_ws -n auto --maxprocesses=15}
+    integration-goethereum: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/go_ethereum -n auto --maxprocesses=15}
+    integration-ethtester: python -I {toxinidir}/scripts/pytest_installed_wheel.py --repo-root {toxinidir} -- {posargs:{toxinidir}/tests/integration/test_ethereum_tester.py -n auto --maxprocesses=15}
     docs: make check-docs-ci
 passenv =
     GETH_BINARY
@@ -47,12 +48,14 @@ basepython =
     windows-wheel: python
 
 [testenv:docs]
+changedir={toxinidir}
 deps =
     .[test,docs]
 commands =
     make check-docs-ci
 
 [testenv:py{310,311,312,313,313t,314,314t}-lint]
+changedir={toxinidir}
 deps=pre-commit
 extras=dev
 commands=
@@ -61,6 +64,7 @@ commands=
 
 [testenv:benchmark]
 basepython=python
+changedir={toxinidir}
 commands=
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 5
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 50
@@ -68,6 +72,7 @@ commands=
 
 
 [testenv:py{310,311,312,313,313t,314,314t}-wheel]
+changedir={toxinidir}
 deps=
     wheel
     build[virtualenv]
@@ -79,6 +84,7 @@ commands=
 skip_install=true
 
 [testenv:windows-wheel]
+changedir={toxinidir}
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
## Summary
- install tox test environments from the built mypyc wheel artifact instead of an editable checkout
- run pytest through an isolated installed-wheel launcher from outside the repo checkout
- fail fast if package imports resolve from the checkout instead of the installed compiled wheel

## Rationale
The storage-key invalid-float case must exercise compiled mypyc runtime type enforcement. CI already builds and downloads the compiled wheel, so tox should install that wheel and prove tests import from it instead of falling back to tracked `.py` source inputs.

Prior attempts either let pytest import source files from the checkout or copied the test tree into a temp directory. This keeps the existing wheel artifact flow and removes that workaround.

## Details
- `tox.ini` now uses `package=wheel`, runs normal test envs from `{envtmpdir}`, and invokes `python -I scripts/pytest_installed_wheel.py`.
- `scripts/pytest_installed_wheel.py` imports `faster_web3`, `faster_ens`, and `faster_web3._utils.method_formatters` before adding the repo root for `tests.*` helper imports.
- The launcher rejects checkout-sourced package imports, verifies `method_formatters` is a compiled extension, then calls pytest with `--import-mode=importlib`.
- Docs, lint, benchmark, and wheel smoke envs remain rooted at `{toxinidir}`.

## Verification
- `tox c -e py312-core` reports `use_develop = False`, `package = wheel`, and the installed-wheel launcher command running from `.tox/py312-core/tmp`.
- `tests/core/utilities/test_method_formatters.py::test_storage_key_to_hexstr[invalid-float]` passed through the installed-wheel launcher.
- Import-path check confirmed `faster_web3` resolves from `.tox/py312-core/lib/python3.12/site-packages` and `method_formatters` resolves to a compiled `.so`.
- The launcher fails instead of falling back to the checkout when no installed package is available.
- Local commit hooks were not used for the final commit because the local hook environment cannot resolve a `python` executable; no lint/pre-commit cleanup was included.