### PR TITLE
fix: annotate contract source compiler mapping

### DIFF
--- a/faster_web3/_utils/contract_sources/compile_contracts.py
+++ b/faster_web3/_utils/contract_sources/compile_contracts.py
@@ -112,7 +112,7 @@ def _get_compiled_contract_data(
     return contract_data
 
 
-contracts_in_file = {}
+contracts_in_file: Dict[str, List[str]] = {}
 
 
 def compile_files(file_list: List[str]) -> None:


### PR DESCRIPTION
## Summary

Adds an explicit `Dict[str, List[str]]` annotation to the contract-source compiler's `contracts_in_file` mapping.

## Rationale

Newer mypyc builds require an annotation for this module-level empty dict and fail wheel builds with `Need type annotation for "contracts_in_file" [var-annotated]` without it.

## Details

- Keeps the change typing-only with no runtime behavior changes.
- Leaves the mypy/mypyc version pins unchanged on `master`.
- Validated with `git diff --check`.
- Validated `python3 -m build --wheel` against the current pinned build backend, producing a compiled CPython 3.12 wheel.
- Validated a scratch `/tmp` wheel build with only `mypy[mypyc]==2.3.0` changed in the scratch `pyproject.toml`; the original `var-annotated` failure no longer reproduces and the compiled wheel build succeeds.

Note: local `git push` was unavailable because this checkout has no HTTPS Git credentials, so the branch commit and PR were created through the authenticated GitHub connector.