### PR TITLE
fix: restore contract data imports from wheels

### DIFF
--- a/build/__native_5f8b22f5f815a3776376.h
+++ b/build/__native_5f8b22f5f815a3776376.h
@@ -2138,8 +2138,8 @@ typedef struct {
     PyObject *___mypyc_temp__18;
     tuple_T3OOO ___mypyc_temp__19;
     PyObject *___mypyc_generator_attribute__unsubscribed;
-    int64_t ___mypyc_temp__2_0;
-    PyObject *___mypyc_temp__2_1;
+    PyObject *___mypyc_temp__2_0;
+    int64_t ___mypyc_temp__2_1;
 } faster_web3___providers___persistent___subscription_manager___unsubscribe_all_SubscriptionManager_genObject;
 
 typedef struct {

--- a/build/__native_faster_web3_contract_source_packages.c
+++ b/build/__native_faster_web3_contract_source_packages.c
@@ -1,0 +1,361 @@
+#ifndef DIFFCHECK_PLACEHOLDER
+#define DIFFCHECK_PLACEHOLDER 0
+#endif
+#include "init.c"
+#include "getargs.c"
+#include "getargsfast.c"
+#include "int_ops.c"
+#include "float_ops.c"
+#include "str_ops.c"
+#include "bytes_ops.c"
+#include "list_ops.c"
+#include "dict_ops.c"
+#include "set_ops.c"
+#include "tuple_ops.c"
+#include "exc_ops.c"
+#include "misc_ops.c"
+#include "generic_ops.c"
+#include "pythonsupport.c"
+#include "function_wrapper.c"
+#include "__native_faster_web3_contract_source_packages.h"
+#include "__native_internal_faster_web3_contract_source_packages.h"
+static PyMethodDef contract_sourcesmodule_methods[] = {
+    {NULL, NULL, 0, NULL}
+};
+
+int CPyExec_faster_web3____utils___contract_sources(PyObject *module)
+{
+    intern_strings();
+    PyObject* modname = NULL;
+    modname = PyObject_GetAttrString((PyObject *)CPyModule_faster_web3____utils___contract_sources__internal, "__name__");
+    CPyStatic_contract_sources___globals = PyModule_GetDict(CPyModule_faster_web3____utils___contract_sources__internal);
+    if (unlikely(CPyStatic_contract_sources___globals == NULL))
+        goto fail;
+    if (CPyGlobalsInit() < 0)
+        goto fail;
+    char result = CPyDef_contract_sources_____top_level__();
+    if (result == 2)
+        goto fail;
+    Py_DECREF(modname);
+    return 0;
+    fail:
+    Py_CLEAR(CPyModule_faster_web3____utils___contract_sources__internal);
+    Py_CLEAR(modname);
+    return -1;
+}
+static struct PyModuleDef contract_sourcesmodule = {
+    PyModuleDef_HEAD_INIT,
+    "faster_web3._utils.contract_sources",
+    NULL, /* docstring */
+    0,       /* size of per-interpreter state of the module */
+    contract_sourcesmodule_methods,
+    NULL,
+};
+
+PyObject *CPyInitOnly_faster_web3____utils___contract_sources(void)
+{
+    if (CPyModule_faster_web3____utils___contract_sources__internal) {
+        Py_INCREF(CPyModule_faster_web3____utils___contract_sources__internal);
+        return CPyModule_faster_web3____utils___contract_sources__internal;
+    }
+    CPyModule_faster_web3____utils___contract_sources__internal = PyModule_Create(&contract_sourcesmodule);
+    return CPyModule_faster_web3____utils___contract_sources__internal;
+}
+
+PyObject *CPyInit_faster_web3____utils___contract_sources(void)
+{
+    PyObject* modname = NULL;
+    if (CPyModule_faster_web3____utils___contract_sources__internal) {
+        Py_INCREF(CPyModule_faster_web3____utils___contract_sources__internal);
+        return CPyModule_faster_web3____utils___contract_sources__internal;
+    }
+    CPyModule_faster_web3____utils___contract_sources__internal = PyModule_Create(&contract_sourcesmodule);
+    if (unlikely(CPyModule_faster_web3____utils___contract_sources__internal == NULL))
+        goto fail;
+    modname = PyUnicode_FromString("faster_web3._utils.contract_sources");
+    if (modname == NULL) CPyError_OutOfMemory();
+    int rv = 0;
+    PyObject *mod_dict = PyImport_GetModuleDict();
+    PyObject *shared_lib = NULL;
+    rv = PyDict_GetItemStringRef(mod_dict, "faster_web3_contract_source_packages__mypyc", &shared_lib);
+    if (rv < 0) goto fail;
+    PyObject *shared_lib_file = PyObject_GetAttrString(shared_lib, "__file__");
+    if (shared_lib_file == NULL) goto fail;
+    PyObject *ext_suffix = PyUnicode_FromString(".cpython-314-x86_64-linux-gnu.so");
+    if (ext_suffix == NULL) CPyError_OutOfMemory();
+    Py_ssize_t is_pkg = 1;
+    rv = CPyImport_SetDunderAttrs(CPyModule_faster_web3____utils___contract_sources__internal, modname, shared_lib_file, ext_suffix, is_pkg);
+    Py_DECREF(ext_suffix);
+    Py_DECREF(shared_lib_file);
+    if (rv < 0) goto fail;
+    if (PyObject_SetItem(PyImport_GetModuleDict(), modname, CPyModule_faster_web3____utils___contract_sources__internal) < 0)
+        goto fail;
+    Py_CLEAR(modname);
+    if (CPyExec_faster_web3____utils___contract_sources(CPyModule_faster_web3____utils___contract_sources__internal) != 0)
+        goto fail;
+    return CPyModule_faster_web3____utils___contract_sources__internal;
+    fail:
+    {
+            PyObject *exc_type, *exc_val, *exc_tb;
+            PyErr_Fetch(&exc_type, &exc_val, &exc_tb);
+            if (modname == NULL) {
+                    modname = PyUnicode_FromString("faster_web3._utils.contract_sources");
+                    if (modname == NULL) CPyError_OutOfMemory();
+                }
+                PyObject_DelItem(PyImport_GetModuleDict(), modname);
+                PyErr_Clear();
+                Py_DECREF(modname);
+                Py_CLEAR(CPyModule_faster_web3____utils___contract_sources__internal);
+                PyErr_Restore(exc_type, exc_val, exc_tb);
+        }
+        return NULL;
+    }
+    
+char CPyDef_contract_sources_____top_level__(void) {
+    PyObject *cpy_r_r0;
+    PyObject *cpy_r_r1;
+    char cpy_r_r2;
+    PyObject *cpy_r_r3;
+    PyObject *cpy_r_r4;
+    char cpy_r_r5;
+    cpy_r_r0 = CPyModule_builtins;
+    cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
+    cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
+    if (cpy_r_r2) goto CPyL3;
+    cpy_r_r3 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'builtins' */
+    cpy_r_r4 = PyImport_Import(cpy_r_r3);
+    if (unlikely(cpy_r_r4 == NULL)) {
+        CPy_AddTraceback("faster_web3/_utils/contract_sources/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_contract_sources___globals);
+        goto CPyL4;
+    }
+    CPyModule_builtins = cpy_r_r4;
+    CPy_INCREF(CPyModule_builtins);
+    CPy_DECREF(cpy_r_r4);
+CPyL3: ;
+    return 1;
+CPyL4: ;
+    cpy_r_r5 = 2;
+    return cpy_r_r5;
+}
+    static PyMethodDef contract_datamodule_methods[] = {
+        {NULL, NULL, 0, NULL}
+    };
+    
+    int CPyExec_faster_web3____utils___contract_sources___contract_data(PyObject *module)
+    {
+        intern_strings();
+        PyObject* modname = NULL;
+        modname = PyObject_GetAttrString((PyObject *)CPyModule_faster_web3____utils___contract_sources___contract_data__internal, "__name__");
+        CPyStatic_contract_data___globals = PyModule_GetDict(CPyModule_faster_web3____utils___contract_sources___contract_data__internal);
+        if (unlikely(CPyStatic_contract_data___globals == NULL))
+            goto fail;
+        if (CPyGlobalsInit() < 0)
+            goto fail;
+        char result = CPyDef_contract_data_____top_level__();
+        if (result == 2)
+            goto fail;
+        Py_DECREF(modname);
+        return 0;
+        fail:
+        Py_CLEAR(CPyModule_faster_web3____utils___contract_sources___contract_data__internal);
+        Py_CLEAR(modname);
+        return -1;
+    }
+    static struct PyModuleDef contract_datamodule = {
+        PyModuleDef_HEAD_INIT,
+        "faster_web3._utils.contract_sources.contract_data",
+        NULL, /* docstring */
+        0,       /* size of per-interpreter state of the module */
+        contract_datamodule_methods,
+        NULL,
+    };
+    
+    PyObject *CPyInitOnly_faster_web3____utils___contract_sources___contract_data(void)
+    {
+        if (CPyModule_faster_web3____utils___contract_sources___contract_data__internal) {
+            Py_INCREF(CPyModule_faster_web3____utils___contract_sources___contract_data__internal);
+            return CPyModule_faster_web3____utils___contract_sources___contract_data__internal;
+        }
+        CPyModule_faster_web3____utils___contract_sources___contract_data__internal = PyModule_Create(&contract_datamodule);
+        return CPyModule_faster_web3____utils___contract_sources___contract_data__internal;
+    }
+    
+    PyObject *CPyInit_faster_web3____utils___contract_sources___contract_data(void)
+    {
+        PyObject* modname = NULL;
+        if (CPyModule_faster_web3____utils___contract_sources___contract_data__internal) {
+            Py_INCREF(CPyModule_faster_web3____utils___contract_sources___contract_data__internal);
+            return CPyModule_faster_web3____utils___contract_sources___contract_data__internal;
+        }
+        CPyModule_faster_web3____utils___contract_sources___contract_data__internal = PyModule_Create(&contract_datamodule);
+        if (unlikely(CPyModule_faster_web3____utils___contract_sources___contract_data__internal == NULL))
+            goto fail;
+        modname = PyUnicode_FromString("faster_web3._utils.contract_sources.contract_data");
+        if (modname == NULL) CPyError_OutOfMemory();
+        int rv = 0;
+        PyObject *mod_dict = PyImport_GetModuleDict();
+        PyObject *shared_lib = NULL;
+        rv = PyDict_GetItemStringRef(mod_dict, "faster_web3_contract_source_packages__mypyc", &shared_lib);
+        if (rv < 0) goto fail;
+        PyObject *shared_lib_file = PyObject_GetAttrString(shared_lib, "__file__");
+        if (shared_lib_file == NULL) goto fail;
+        PyObject *ext_suffix = PyUnicode_FromString(".cpython-314-x86_64-linux-gnu.so");
+        if (ext_suffix == NULL) CPyError_OutOfMemory();
+        Py_ssize_t is_pkg = 1;
+        rv = CPyImport_SetDunderAttrs(CPyModule_faster_web3____utils___contract_sources___contract_data__internal, modname, shared_lib_file, ext_suffix, is_pkg);
+        Py_DECREF(ext_suffix);
+        Py_DECREF(shared_lib_file);
+        if (rv < 0) goto fail;
+        if (PyObject_SetItem(PyImport_GetModuleDict(), modname, CPyModule_faster_web3____utils___contract_sources___contract_data__internal) < 0)
+            goto fail;
+        Py_CLEAR(modname);
+        if (CPyExec_faster_web3____utils___contract_sources___contract_data(CPyModule_faster_web3____utils___contract_sources___contract_data__internal) != 0)
+            goto fail;
+        return CPyModule_faster_web3____utils___contract_sources___contract_data__internal;
+        fail:
+        {
+                PyObject *exc_type, *exc_val, *exc_tb;
+                PyErr_Fetch(&exc_type, &exc_val, &exc_tb);
+                if (modname == NULL) {
+                        modname = PyUnicode_FromString("faster_web3._utils.contract_sources.contract_data");
+                        if (modname == NULL) CPyError_OutOfMemory();
+                    }
+                    PyObject_DelItem(PyImport_GetModuleDict(), modname);
+                    PyErr_Clear();
+                    Py_DECREF(modname);
+                    Py_CLEAR(CPyModule_faster_web3____utils___contract_sources___contract_data__internal);
+                    PyErr_Restore(exc_type, exc_val, exc_tb);
+            }
+            return NULL;
+        }
+        
+char CPyDef_contract_data_____top_level__(void) {
+    PyObject *cpy_r_r0;
+    PyObject *cpy_r_r1;
+    char cpy_r_r2;
+    PyObject *cpy_r_r3;
+    PyObject *cpy_r_r4;
+    char cpy_r_r5;
+    cpy_r_r0 = CPyModule_builtins;
+    cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
+    cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
+    if (cpy_r_r2) goto CPyL3;
+    cpy_r_r3 = CPyStatics[DIFFCHECK_PLACEHOLDER]; /* 'builtins' */
+    cpy_r_r4 = PyImport_Import(cpy_r_r3);
+    if (unlikely(cpy_r_r4 == NULL)) {
+        CPy_AddTraceback("faster_web3/_utils/contract_sources/contract_data/__init__.py", "<module>", DIFFCHECK_PLACEHOLDER, CPyStatic_contract_data___globals);
+        goto CPyL4;
+    }
+    CPyModule_builtins = cpy_r_r4;
+    CPy_INCREF(CPyModule_builtins);
+    CPy_DECREF(cpy_r_r4);
+CPyL3: ;
+    return 1;
+CPyL4: ;
+    cpy_r_r5 = 2;
+    return cpy_r_r5;
+}
+        
+        int CPyGlobalsInit(void)
+        {
+            static int is_initialized = 0;
+            if (is_initialized) return 0;
+            
+            CPy_Init();
+            CPyModule_faster_web3____utils___contract_sources = Py_None;
+            CPyModule_builtins = Py_None;
+            CPyModule_faster_web3____utils___contract_sources___contract_data = Py_None;
+            CPyModule_builtins = Py_None;
+            if (CPyStatics_Initialize(CPyStatics, CPyLit_Str, CPyLit_Bytes, CPyLit_Int, CPyLit_Float, CPyLit_Complex, CPyLit_Tuple, CPyLit_FrozenSet) < 0) {
+                return -1;
+            }
+            is_initialized = 1;
+            return 0;
+        }
+        
+        PyObject *CPyStatics[DIFFCHECK_PLACEHOLDER];
+        const char * const CPyLit_Str[] = {
+    "\001\bbuiltins",
+    "",
+};
+        const char * const CPyLit_Bytes[] = {
+    "",
+};
+        const char * const CPyLit_Int[] = {
+    "",
+};
+        const double CPyLit_Float[] = {0};
+        const double CPyLit_Complex[] = {0};
+        const int CPyLit_Tuple[] = {0};
+        const int CPyLit_FrozenSet[] = {0};
+        CPyModule *CPyModule_faster_web3____utils___contract_sources__internal = NULL;
+        CPyModule *CPyModule_faster_web3____utils___contract_sources;
+        PyObject *CPyStatic_contract_sources___globals;
+        CPyModule *CPyModule_builtins;
+        int CPyExec_faster_web3____utils___contract_sources(PyObject *module);
+        PyObject *CPyInit_faster_web3____utils___contract_sources(void);
+        PyObject *CPyInitOnly_faster_web3____utils___contract_sources(void);
+        CPyModule *CPyModule_faster_web3____utils___contract_sources___contract_data__internal = NULL;
+        CPyModule *CPyModule_faster_web3____utils___contract_sources___contract_data;
+        PyObject *CPyStatic_contract_data___globals;
+        int CPyExec_faster_web3____utils___contract_sources___contract_data(PyObject *module);
+        PyObject *CPyInit_faster_web3____utils___contract_sources___contract_data(void);
+        PyObject *CPyInitOnly_faster_web3____utils___contract_sources___contract_data(void);
+        char CPyDef_contract_sources_____top_level__(void);
+        char CPyDef_contract_data_____top_level__(void);
+        
+        static int exec_faster_web3_contract_source_packages__mypyc(PyObject *module)
+        {
+            int res;
+            PyObject *capsule;
+            PyObject *tmp;
+            
+            extern PyObject *CPyInit_faster_web3____utils___contract_sources(void);
+            capsule = PyCapsule_New((void *)CPyInit_faster_web3____utils___contract_sources, "faster_web3_contract_source_packages__mypyc.init_faster_web3____utils___contract_sources", NULL);
+            if (!capsule) {
+                goto fail;
+            }
+            res = PyObject_SetAttrString(module, "init_faster_web3____utils___contract_sources", capsule);
+            Py_DECREF(capsule);
+            if (res < 0) {
+                goto fail;
+            }
+            
+            extern PyObject *CPyInit_faster_web3____utils___contract_sources___contract_data(void);
+            capsule = PyCapsule_New((void *)CPyInit_faster_web3____utils___contract_sources___contract_data, "faster_web3_contract_source_packages__mypyc.init_faster_web3____utils___contract_sources___contract_data", NULL);
+            if (!capsule) {
+                goto fail;
+            }
+            res = PyObject_SetAttrString(module, "init_faster_web3____utils___contract_sources___contract_data", capsule);
+            Py_DECREF(capsule);
+            if (res < 0) {
+                goto fail;
+            }
+            
+            return 0;
+            fail:
+            return -1;
+        }
+        static PyModuleDef module_def_faster_web3_contract_source_packages__mypyc = {
+            PyModuleDef_HEAD_INIT,
+            .m_name = "faster_web3_contract_source_packages__mypyc",
+            .m_doc = NULL,
+            .m_size = -1,
+            .m_methods = NULL,
+        };
+        PyMODINIT_FUNC PyInit_faster_web3_contract_source_packages__mypyc(void) {
+            static PyObject *module = NULL;
+            if (module) {
+                Py_INCREF(module);
+                return module;
+            }
+            module = PyModule_Create(&module_def_faster_web3_contract_source_packages__mypyc);
+            if (!module) {
+                return NULL;
+            }
+            if (exec_faster_web3_contract_source_packages__mypyc(module) < 0) {
+                Py_DECREF(module);
+                return NULL;
+            }
+            return module;
+        }

--- a/build/__native_faster_web3_contract_source_packages.h
+++ b/build/__native_faster_web3_contract_source_packages.h
@@ -1,0 +1,5 @@
+#ifndef MYPYC_NATIVE_faster_web3_contract_source_packages_H
+#define MYPYC_NATIVE_faster_web3_contract_source_packages_H
+#include <Python.h>
+#include <CPy.h>
+#endif

--- a/build/__native_internal_faster_web3_contract_source_packages.h
+++ b/build/__native_internal_faster_web3_contract_source_packages.h
@@ -1,0 +1,32 @@
+#ifndef MYPYC_LIBRT_INTERNAL_faster_web3_contract_source_packages_H
+#define MYPYC_LIBRT_INTERNAL_faster_web3_contract_source_packages_H
+#include <Python.h>
+#include <CPy.h>
+#include "__native_faster_web3_contract_source_packages.h"
+
+int CPyGlobalsInit(void);
+
+extern PyObject *CPyStatics[4];
+extern const char * const CPyLit_Str[];
+extern const char * const CPyLit_Bytes[];
+extern const char * const CPyLit_Int[];
+extern const double CPyLit_Float[];
+extern const double CPyLit_Complex[];
+extern const int CPyLit_Tuple[];
+extern const int CPyLit_FrozenSet[];
+extern CPyModule *CPyModule_faster_web3____utils___contract_sources__internal;
+extern CPyModule *CPyModule_faster_web3____utils___contract_sources;
+extern PyObject *CPyStatic_contract_sources___globals;
+extern CPyModule *CPyModule_builtins;
+extern int CPyExec_faster_web3____utils___contract_sources(PyObject *module);
+extern PyObject *CPyInit_faster_web3____utils___contract_sources(void);
+extern PyObject *CPyInitOnly_faster_web3____utils___contract_sources(void);
+extern CPyModule *CPyModule_faster_web3____utils___contract_sources___contract_data__internal;
+extern CPyModule *CPyModule_faster_web3____utils___contract_sources___contract_data;
+extern PyObject *CPyStatic_contract_data___globals;
+extern int CPyExec_faster_web3____utils___contract_sources___contract_data(PyObject *module);
+extern PyObject *CPyInit_faster_web3____utils___contract_sources___contract_data(void);
+extern PyObject *CPyInitOnly_faster_web3____utils___contract_sources___contract_data(void);
+extern char CPyDef_contract_sources_____top_level__(void);
+extern char CPyDef_contract_data_____top_level__(void);
+#endif

--- a/build/faster_web3/_utils/contract_sources.c
+++ b/build/faster_web3/_utils/contract_sources.c
@@ -4,11 +4,11 @@ PyMODINIT_FUNC
 PyInit_contract_sources(void)
 {
     PyObject *tmp;
-    if (!(tmp = PyImport_ImportModule("faster_web3._utils.contract_sources__mypyc"))) return NULL;
+    if (!(tmp = PyImport_ImportModule("faster_web3_contract_source_packages__mypyc"))) return NULL;
     PyObject *capsule = PyObject_GetAttrString(tmp, "init_faster_web3____utils___contract_sources");
     Py_DECREF(tmp);
     if (capsule == NULL) return NULL;
-    void *init_func = PyCapsule_GetPointer(capsule, "faster_web3._utils.contract_sources__mypyc.init_faster_web3____utils___contract_sources");
+    void *init_func = PyCapsule_GetPointer(capsule, "faster_web3_contract_source_packages__mypyc.init_faster_web3____utils___contract_sources");
     Py_DECREF(capsule);
     if (!init_func) {
         return NULL;

--- a/build/faster_web3/_utils/contract_sources/contract_data.c
+++ b/build/faster_web3/_utils/contract_sources/contract_data.c
@@ -4,11 +4,11 @@ PyMODINIT_FUNC
 PyInit_contract_data(void)
 {
     PyObject *tmp;
-    if (!(tmp = PyImport_ImportModule("faster_web3._utils.contract_sources.contract_data__mypyc"))) return NULL;
+    if (!(tmp = PyImport_ImportModule("faster_web3_contract_source_packages__mypyc"))) return NULL;
     PyObject *capsule = PyObject_GetAttrString(tmp, "init_faster_web3____utils___contract_sources___contract_data");
     Py_DECREF(tmp);
     if (capsule == NULL) return NULL;
-    void *init_func = PyCapsule_GetPointer(capsule, "faster_web3._utils.contract_sources.contract_data__mypyc.init_faster_web3____utils___contract_sources___contract_data");
+    void *init_func = PyCapsule_GetPointer(capsule, "faster_web3_contract_source_packages__mypyc.init_faster_web3____utils___contract_sources___contract_data");
     Py_DECREF(capsule);
     if (!init_func) {
         return NULL;

--- a/faster_web3/scripts/release/test_wheel_install.sh
+++ b/faster_web3/scripts/release/test_wheel_install.sh
@@ -35,10 +35,13 @@ python -m pip install --upgrade "$wheel_path"
 cd "$temp_dir"
 python - <<'PY'
 from faster_web3 import Web3
+import faster_web3._utils.contract_sources.contract_data.emitter_contract as emitter_contract
 import faster_web3._utils.method_formatters as method_formatters
 
-compiled_path = method_formatters.__file__
-assert compiled_path.endswith((".so", ".pyd")), compiled_path
+for compiled_module in (method_formatters, emitter_contract):
+    compiled_path = compiled_module.__file__
+    assert compiled_path.endswith((".so", ".pyd")), compiled_path
+    print(compiled_path)
+
 print(Web3)
-print(compiled_path)
 PY

--- a/faster_web3/scripts/release/test_wheel_install.sh
+++ b/faster_web3/scripts/release/test_wheel_install.sh
@@ -34,13 +34,24 @@ python -m pip install --upgrade pip
 python -m pip install --upgrade "$wheel_path"
 cd "$temp_dir"
 python - <<'PY'
+from pathlib import Path
+
 from faster_web3 import Web3
+import faster_web3._utils.contract_sources as contract_sources
+import faster_web3._utils.contract_sources.contract_data as contract_data
 import faster_web3._utils.contract_sources.contract_data.emitter_contract as emitter_contract
 import faster_web3._utils.method_formatters as method_formatters
 
-for compiled_module in (method_formatters, emitter_contract):
+for compiled_module in (
+    method_formatters,
+    contract_sources,
+    contract_data,
+    emitter_contract,
+):
     compiled_path = compiled_module.__file__
     assert compiled_path.endswith((".so", ".pyd")), compiled_path
+    if hasattr(compiled_module, "__path__"):
+        assert list(compiled_module.__path__) == [str(Path(compiled_path).parent)]
     print(compiled_path)
 
 print(Web3)

--- a/faster_web3/scripts/release/test_windows_wheel_install.sh
+++ b/faster_web3/scripts/release/test_windows_wheel_install.sh
@@ -36,13 +36,24 @@ python -m pip install --upgrade pip
 python -m pip install --upgrade "$wheel_path" --progress-bar off
 cd "$temp_dir"
 python - <<'PY'
+from pathlib import Path
+
 from faster_web3 import Web3
+import faster_web3._utils.contract_sources as contract_sources
+import faster_web3._utils.contract_sources.contract_data as contract_data
 import faster_web3._utils.contract_sources.contract_data.emitter_contract as emitter_contract
 import faster_web3._utils.method_formatters as method_formatters
 
-for compiled_module in (method_formatters, emitter_contract):
+for compiled_module in (
+    method_formatters,
+    contract_sources,
+    contract_data,
+    emitter_contract,
+):
     compiled_path = compiled_module.__file__
     assert compiled_path.endswith(".pyd"), compiled_path
+    if hasattr(compiled_module, "__path__"):
+        assert list(compiled_module.__path__) == [str(Path(compiled_path).parent)]
     print(compiled_path)
 
 print(Web3)

--- a/faster_web3/scripts/release/test_windows_wheel_install.sh
+++ b/faster_web3/scripts/release/test_windows_wheel_install.sh
@@ -37,10 +37,13 @@ python -m pip install --upgrade "$wheel_path" --progress-bar off
 cd "$temp_dir"
 python - <<'PY'
 from faster_web3 import Web3
+import faster_web3._utils.contract_sources.contract_data.emitter_contract as emitter_contract
 import faster_web3._utils.method_formatters as method_formatters
 
-compiled_path = method_formatters.__file__
-assert compiled_path.endswith(".pyd"), compiled_path
+for compiled_module in (method_formatters, emitter_contract):
+    compiled_path = compiled_module.__file__
+    assert compiled_path.endswith(".pyd"), compiled_path
+    print(compiled_path)
+
 print(Web3)
-print(compiled_path)
 PY

--- a/scripts/pytest_installed_wheel.py
+++ b/scripts/pytest_installed_wheel.py
@@ -5,9 +5,11 @@ import importlib.machinery
 import pathlib
 import sys
 
-
 DEFAULT_PACKAGES = ("faster_web3", "faster_ens")
-DEFAULT_COMPILED_MODULES = ("faster_web3._utils.method_formatters",)
+DEFAULT_COMPILED_MODULES = (
+    "faster_web3._utils.method_formatters",
+    "faster_web3._utils.contract_sources.contract_data.emitter_contract",
+)
 
 
 def _resolve_path_entry(path_entry: str) -> pathlib.Path:

--- a/scripts/pytest_installed_wheel.py
+++ b/scripts/pytest_installed_wheel.py
@@ -8,6 +8,8 @@ import sys
 DEFAULT_PACKAGES = ("faster_web3", "faster_ens")
 DEFAULT_COMPILED_MODULES = (
     "faster_web3._utils.method_formatters",
+    "faster_web3._utils.contract_sources",
+    "faster_web3._utils.contract_sources.contract_data",
     "faster_web3._utils.contract_sources.contract_data.emitter_contract",
 )
 
@@ -65,6 +67,18 @@ def _assert_compiled(module_name: str, repo_root: pathlib.Path) -> None:
         raise RuntimeError(
             f"{module_name} imported from {module_path}; expected a compiled extension"
         )
+    module = sys.modules[module_name]
+    module_search_locations = getattr(module, "__path__", None)
+    if module_search_locations is not None:
+        expected_path = module_path.parent.resolve(strict=False)
+        actual_paths = [
+            pathlib.Path(path_entry).resolve(strict=False)
+            for path_entry in module_search_locations
+        ]
+        if actual_paths != [expected_path]:
+            raise RuntimeError(
+                f"{module_name} has __path__ {actual_paths}; expected {[expected_path]}"
+            )
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,10 @@ if not skip_mypyc:
         for p in Path("faster_web3/_utils/contract_sources").rglob("*.py")
         if p.name != "__init__.py"
     )
+    contract_source_package_files: list[str] = sorted(
+        str(p.as_posix())
+        for p in Path("faster_web3/_utils/contract_sources").rglob("__init__.py")
+    )
     ens_data_files: list[str] = ["faster_ens/abis.py", "faster_ens/contract_data.py"]
 
     if sys.platform.startswith("win"):
@@ -167,6 +171,12 @@ if not skip_mypyc:
     if not sys.platform.startswith("win"):
         benchmark_tooling_unit = mypycify(benchmark_tooling_files + flags)
         ext_modules.extend(benchmark_tooling_unit)
+
+    contract_source_package_unit = mypycify(
+        contract_source_package_files + flags,
+        group_name="faster_web3_contract_source_packages",
+    )
+    ext_modules.extend(contract_source_package_unit)
 
     # these do not need to be part of the same compilation unit as the rest of the library
     for data_file in web3_data_files + ens_data_files:

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-import sys
 from pathlib import (
     Path,
+)
+import sys
+
+from mypyc.build import (
+    mypycify,
 )
 from setuptools import (
     Extension,
     find_packages,
     setup,
 )
-from mypyc.build import mypycify
 
 
 def read_requirements(path: str) -> list[str]:
@@ -131,6 +134,7 @@ if not skip_mypyc:
     web3_data_files: list[str] = sorted(
         str(p.as_posix())
         for p in Path("faster_web3/_utils/contract_sources").rglob("*.py")
+        if p.name != "__init__.py"
     )
     ens_data_files: list[str] = ["faster_ens/abis.py", "faster_ens/contract_data.py"]
 


### PR DESCRIPTION
Exclude package initializers from the contract source mypyc sweep so installed wheels expose nested contract data modules, and extend wheel smoke checks to catch regressions.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
